### PR TITLE
ci: server-side guard against the banned commit identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,42 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  # Server-side enforcement of the check-in identity rule: the local pre-commit
+  # hook can be bypassed with --no-verify, this gate cannot. The banned string is
+  # assembled at runtime so this file stays clean and never trips its own check.
+  identity-guard:
+    name: identity-guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - name: Forbid the banned commit identity
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          banned="$(printf 'd%s' 'bowles')"
+          fail=0
+          # 1. No tracked file may contain the banned word (the hook dir may name it).
+          if git grep -nIi "$banned" -- . ':(exclude).githooks/'; then
+            echo "::error::tracked content contains the banned identity"
+            fail=1
+          fi
+          # 2. No commit in range may be authored/committed by the banned account.
+          if [ -n "${BASE:-}" ] && [ -n "${HEAD:-}" ]; then
+            range="$BASE..$HEAD"
+          else
+            range="HEAD~1..HEAD"
+          fi
+          if git log --format='%an <%ae>%n%cn <%ce>' "$range" | grep -i "$banned"; then
+            echo "::error::a commit in $range is authored/committed by the banned identity"
+            fail=1
+          fi
+          [ "$fail" -eq 0 ] && echo "OK: banned identity absent from content and commits ($range)"
+          exit "$fail"
+
   check:
     name: Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Mirror of sapwood's `identity-guard` (sapwood#39). A local pre-commit hook can be bypassed with `--no-verify`; this CI job cannot. Fails the build if the banned account authored/committed any commit in the PR range, or if its name appears in tracked content (the hook dir is excluded — it legitimately names what it bans).

Banned string assembled at runtime so this workflow stays clean (0 literal occurrences) and never trips its own check.