### PR TITLE
feat: relay-to-serial signing bridge (HSM-mode data plane)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ Heartwood is a dedicated Nostr signing appliance. It runs on a Raspberry Pi Zero
 
 ## Architecture overview
 
-The repo has two runtime components: a Rust binary (`heartwood-device`) and a Node.js sidecar (`bunker/`). The Rust side handles the web UI, storage, optional Tor (fronting the web UI), and OLED. The Node.js bunker sidecar connects to Nostr relays as a NIP-46 server, handling `connect` and `ping` itself and forwarding signing/derivation requests to the Rust crate library.
+The repo has three runtime components: a Rust binary (`heartwood-device`), a Node.js sidecar (`bunker/`), and a Rust sidecar (`heartwood-bridge`). The Rust device binary handles the web UI, storage, optional Tor (fronting the web UI), and OLED. The Node.js bunker sidecar connects to Nostr relays as a NIP-46 server, handling `connect` and `ping` itself and forwarding signing/derivation requests to the Rust crate library — this is the **software-signing** path. The `heartwood-bridge` sidecar is its **HSM-mode** counterpart: it connects the relays to a USB-tethered signing device, pumping NIP-46 requests over serial and publishing the device's signed responses, while never holding key material itself. The bunker and the bridge are mutually exclusive by operational mode (see [the bridge design note](docs/2026-06-25-relay-serial-bridge.md)).
 
 ## Hexagonal architecture
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/heartwood-core",
     "crates/heartwood-nip46",
     "crates/heartwood-device",
+    "crates/heartwood-bridge",
 ]
 
 [workspace.package]

--- a/boards/pi/heartwood-bridge@.service
+++ b/boards/pi/heartwood-bridge@.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=Heartwood relay-to-serial signing bridge (%i)
+After=network-online.target heartwood@%i.service
+Wants=network-online.target
+Requires=heartwood@%i.service
+PartOf=heartwood@%i.service
+StartLimitBurst=10
+StartLimitIntervalSec=300
+
+[Service]
+Type=simple
+User=heartwood
+Group=heartwood
+# The device enumerates on a serial tty, which is owned by the dialout group.
+SupplementaryGroups=dialout
+ExecStart=/usr/local/bin/heartwood-bridge
+Restart=always
+RestartSec=15
+Environment=RUST_LOG=info
+Environment=HEARTWOOD_DATA_DIR=/var/lib/heartwood/%i
+
+# Security hardening
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/heartwood/%i
+NoNewPrivileges=true
+PrivateTmp=true
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+# Only the USB-serial character devices the tethered HSM can appear as.
+DevicePolicy=closed
+DeviceAllow=char-ttyUSB rw
+DeviceAllow=char-ttyACM rw
+
+[Install]
+WantedBy=multi-user.target

--- a/crates/heartwood-bridge/Cargo.toml
+++ b/crates/heartwood-bridge/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "heartwood-bridge"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Relay-to-serial signing bridge: pumps NIP-46 traffic between Nostr relays and a USB-tethered Heartwood HSM (ESP32/ESP8266)"
+keywords = ["nostr", "nip46", "signing", "serial", "esp32"]
+categories = ["cryptography", "command-line-utilities"]
+
+[dependencies]
+# Async runtime + signal handling for graceful systemd shutdown.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync", "io-util", "signal"] }
+# Relay transport. rustls (not native-tls) so the Pi cross-build needs no
+# system OpenSSL; webpki-roots bundles the Mozilla CA set.
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = { version = "0.3", features = ["sink"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Blocking serial transport to the device (same crate the Pi web binary uses).
+serialport = "4"
+crc32fast = "1"
+# npub (bech32) decoding for the master public key discovered over serial.
+bech32 = "0.11"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/crates/heartwood-bridge/src/bridge.rs
+++ b/crates/heartwood-bridge/src/bridge.rs
@@ -1,0 +1,115 @@
+//! The serial worker.
+//!
+//! Owns the single serial port on a dedicated OS thread (serial I/O is
+//! blocking), processes signing jobs strictly sequentially — the device
+//! handles one request at a time — and broadcasts each signed response to the
+//! relay tasks. On serial failure it reopens and re-authenticates, retrying
+//! forever; the bridge is useless without the device, so it simply waits.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+use crate::config::Config;
+use crate::relay::RequestJob;
+use crate::serial::SerialSession;
+
+const REOPEN_BACKOFF: Duration = Duration::from_secs(3);
+
+/// Spawn the serial worker. It authenticates, reports the discovered master
+/// pubkeys through `masters_tx` (so the relay tasks can build their filters),
+/// then loops over jobs from `job_rx`, broadcasting responses on `resp_tx`.
+pub fn spawn_serial_worker(
+    config: Config,
+    mut job_rx: mpsc::Receiver<RequestJob>,
+    resp_tx: broadcast::Sender<String>,
+    masters_tx: oneshot::Sender<Vec<String>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name("serial-worker".into())
+        .spawn(move || {
+            let mut session = connect_blocking(&config);
+
+            // Discover masters (retrying the whole session on failure).
+            let masters = loop {
+                match session.list_master_pubkeys() {
+                    Ok(masters) => break masters,
+                    Err(e) => {
+                        tracing::error!("provision-list failed: {e:#}; reopening");
+                        std::thread::sleep(REOPEN_BACKOFF);
+                        session = connect_blocking(&config);
+                    }
+                }
+            };
+            tracing::info!("device masters: {}", join_short(&masters));
+            if masters_tx.send(masters).is_err() {
+                tracing::error!("main task gone before masters delivered; aborting worker");
+                return;
+            }
+
+            // Process signing jobs sequentially.
+            while let Some(job) = job_rx.blocking_recv() {
+                let created_at = crate::now_unix();
+                let payload = match job.request.encrypted_request_payload(created_at) {
+                    Ok(payload) => payload,
+                    Err(e) => {
+                        tracing::warn!("dropping malformed request payload: {e:#}");
+                        continue;
+                    }
+                };
+                let client = short(&job.request.client_pubkey_hex);
+                match session.sign(&payload) {
+                    Ok(Some(event_json)) => {
+                        tracing::info!(client = %client, "signed response ({} bytes)", event_json.len());
+                        let _ = resp_tx.send(event_json);
+                    }
+                    Ok(None) => {
+                        tracing::warn!(client = %client, "device NACKed (unknown master / decrypt / policy)");
+                    }
+                    Err(e) => {
+                        tracing::error!("serial sign failed: {e:#}; reopening port");
+                        session = connect_blocking(&config);
+                    }
+                }
+            }
+
+            tracing::info!("serial worker stopping (job channel closed)");
+        })
+        .expect("spawn serial worker thread")
+}
+
+/// Open + authenticate, retrying forever with backoff.
+fn connect_blocking(config: &Config) -> SerialSession {
+    loop {
+        match try_connect(config) {
+            Ok(session) => return session,
+            Err(e) => {
+                tracing::error!(
+                    "serial connect failed: {e:#}; retry in {}s",
+                    REOPEN_BACKOFF.as_secs()
+                );
+                std::thread::sleep(REOPEN_BACKOFF);
+            }
+        }
+    }
+}
+
+fn try_connect(config: &Config) -> Result<SerialSession> {
+    let mut session = SerialSession::open(&config.serial_port)?;
+    match session.firmware_info() {
+        Ok(info) => tracing::info!("device firmware: {info}"),
+        Err(e) => tracing::debug!("firmware-info unavailable: {e:#}"),
+    }
+    session.authenticate(&config.bridge_secret)?;
+    tracing::info!("bridge session authenticated");
+    Ok(session)
+}
+
+fn short(hex: &str) -> &str {
+    &hex[..hex.len().min(12)]
+}
+
+fn join_short(masters: &[String]) -> String {
+    masters.iter().map(|m| short(m)).collect::<Vec<_>>().join(", ")
+}

--- a/crates/heartwood-bridge/src/config.rs
+++ b/crates/heartwood-bridge/src/config.rs
@@ -1,0 +1,124 @@
+//! Bridge configuration, read from the shared instance data directory.
+//!
+//! The bridge is a sidecar to `heartwood-device` and shares its data dir
+//! (`HEARTWOOD_DATA_DIR`, default `/var/lib/heartwood`, or `…/<instance>`). It
+//! reads three things and holds no key material of its own:
+//!
+//!   - `master.payload` — the unlocked payload. In HSM mode this is the string
+//!     `hsm:<serial_port>` (no secret); any other value means this instance is
+//!     not an HSM instance and the bridge has nothing to do.
+//!   - `config.json` — the operator's relay list (`relays`).
+//!   - `bridge.secret` — the 32-byte serial bridge-session secret (64-char hex,
+//!     or 32 raw bytes), the same value provisioned into the device's NVS.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+
+/// Relays used when `config.json` names none (matches the Pi web binary).
+pub const DEFAULT_RELAYS: &[&str] =
+    &["wss://relay.damus.io", "wss://nos.lol", "wss://relay.trotters.cc"];
+
+pub struct Config {
+    pub data_dir: PathBuf,
+    pub serial_port: String,
+    pub relays: Vec<String>,
+    pub bridge_secret: [u8; 32],
+}
+
+impl Config {
+    pub fn load() -> Result<Self> {
+        let data_dir = PathBuf::from(
+            std::env::var("HEARTWOOD_DATA_DIR").unwrap_or_else(|_| "/var/lib/heartwood".to_string()),
+        );
+        let serial_port = read_hsm_serial_port(&data_dir)?;
+        let relays = read_relays(&data_dir);
+        let bridge_secret = read_bridge_secret(&data_dir)?;
+        Ok(Self { data_dir, serial_port, relays, bridge_secret })
+    }
+}
+
+fn read_hsm_serial_port(data_dir: &Path) -> Result<String> {
+    let path = data_dir.join("master.payload");
+    let payload = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading {} (is the device unlocked?)", path.display()))?;
+    match payload.trim().strip_prefix("hsm:") {
+        Some(port) if !port.is_empty() => Ok(port.to_string()),
+        Some(_) => bail!("master.payload has an empty 'hsm:' serial port"),
+        None => bail!(
+            "instance is not in HSM mode (master.payload is not 'hsm:<port>') — \
+             the bridge only serves HSM-mode instances"
+        ),
+    }
+}
+
+fn read_relays(data_dir: &Path) -> Vec<String> {
+    let path = data_dir.join("config.json");
+    let configured = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        .and_then(|v| v.get("relays").cloned())
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v).ok());
+    match configured {
+        Some(relays) if !relays.is_empty() => relays,
+        _ => DEFAULT_RELAYS.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn read_bridge_secret(data_dir: &Path) -> Result<[u8; 32]> {
+    let path = data_dir.join("bridge.secret");
+    let raw = std::fs::read(&path).with_context(|| {
+        format!("reading {} — provision the bridge secret over USB first", path.display())
+    })?;
+    parse_bridge_secret(&raw)
+}
+
+/// Accept either 64 hex chars (whitespace ignored) or exactly 32 raw bytes.
+fn parse_bridge_secret(raw: &[u8]) -> Result<[u8; 32]> {
+    let stripped: Vec<u8> = raw.iter().copied().filter(|b| !b.is_ascii_whitespace()).collect();
+    if stripped.len() == 64 && stripped.iter().all(|b| b.is_ascii_hexdigit()) {
+        let mut out = [0u8; 32];
+        for (i, chunk) in stripped.chunks(2).enumerate() {
+            let hi = (chunk[0] as char).to_digit(16).ok_or_else(|| anyhow!("bad hex digit"))?;
+            let lo = (chunk[1] as char).to_digit(16).ok_or_else(|| anyhow!("bad hex digit"))?;
+            out[i] = ((hi << 4) | lo) as u8;
+        }
+        return Ok(out);
+    }
+    if raw.len() == 32 {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(raw);
+        return Ok(out);
+    }
+    bail!(
+        "bridge.secret must be 64 hex chars or exactly 32 raw bytes (got {} bytes)",
+        raw.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hex_secret_with_trailing_newline() {
+        let hex = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\n";
+        let s = parse_bridge_secret(hex.as_bytes()).unwrap();
+        assert_eq!(s[0], 0x00);
+        assert_eq!(s[1], 0x11);
+        assert_eq!(s[31], 0xff);
+    }
+
+    #[test]
+    fn parses_raw_32_byte_secret() {
+        let raw = [7u8; 32];
+        assert_eq!(parse_bridge_secret(&raw).unwrap(), raw);
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert!(parse_bridge_secret(b"too short").is_err());
+        assert!(parse_bridge_secret(&[0u8; 31]).is_err());
+    }
+}

--- a/crates/heartwood-bridge/src/config.rs
+++ b/crates/heartwood-bridge/src/config.rs
@@ -30,7 +30,8 @@ pub struct Config {
 impl Config {
     pub fn load() -> Result<Self> {
         let data_dir = PathBuf::from(
-            std::env::var("HEARTWOOD_DATA_DIR").unwrap_or_else(|_| "/var/lib/heartwood".to_string()),
+            std::env::var("HEARTWOOD_DATA_DIR")
+                .unwrap_or_else(|_| "/var/lib/heartwood".to_string()),
         );
         let serial_port = read_hsm_serial_port(&data_dir)?;
         let relays = read_relays(&data_dir);
@@ -91,10 +92,7 @@ fn parse_bridge_secret(raw: &[u8]) -> Result<[u8; 32]> {
         out.copy_from_slice(raw);
         return Ok(out);
     }
-    bail!(
-        "bridge.secret must be 64 hex chars or exactly 32 raw bytes (got {} bytes)",
-        raw.len()
-    )
+    bail!("bridge.secret must be 64 hex chars or exactly 32 raw bytes (got {} bytes)", raw.len())
 }
 
 #[cfg(test)]

--- a/crates/heartwood-bridge/src/dedup.rs
+++ b/crates/heartwood-bridge/src/dedup.rs
@@ -22,10 +22,7 @@ struct Inner {
 impl Seen {
     pub fn new(capacity: usize) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(Inner {
-                set: HashSet::new(),
-                order: VecDeque::new(),
-            })),
+            inner: Arc::new(Mutex::new(Inner { set: HashSet::new(), order: VecDeque::new() })),
             capacity: capacity.max(1),
         }
     }

--- a/crates/heartwood-bridge/src/dedup.rs
+++ b/crates/heartwood-bridge/src/dedup.rs
@@ -1,0 +1,84 @@
+//! Bounded de-duplication set for request event ids.
+//!
+//! The same NIP-46 request usually arrives from several relays at once. We must
+//! forward it to the device exactly once, so each relay task checks ids against
+//! this shared set before queuing work. The set is bounded with FIFO eviction
+//! so it cannot grow without limit on a long-running daemon.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct Seen {
+    inner: Arc<Mutex<Inner>>,
+    capacity: usize,
+}
+
+struct Inner {
+    set: HashSet<String>,
+    order: VecDeque<String>,
+}
+
+impl Seen {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                set: HashSet::new(),
+                order: VecDeque::new(),
+            })),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Record an id. Returns `true` if it was not already present — i.e. the
+    /// caller is the first to see it and should process the request.
+    pub fn insert(&self, id: &str) -> bool {
+        if id.is_empty() {
+            // An id-less event cannot be de-duplicated; let it through rather
+            // than silently swallow it.
+            return true;
+        }
+        let mut inner = self.inner.lock().unwrap();
+        if inner.set.contains(id) {
+            return false;
+        }
+        inner.set.insert(id.to_string());
+        inner.order.push_back(id.to_string());
+        while inner.order.len() > self.capacity {
+            if let Some(old) = inner.order.pop_front() {
+                inner.set.remove(&old);
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_insert_is_new_then_duplicate() {
+        let seen = Seen::new(16);
+        assert!(seen.insert("abc"));
+        assert!(!seen.insert("abc"));
+        assert!(seen.insert("def"));
+    }
+
+    #[test]
+    fn evicts_oldest_past_capacity() {
+        let seen = Seen::new(2);
+        assert!(seen.insert("a"));
+        assert!(seen.insert("b"));
+        assert!(seen.insert("c")); // evicts "a"
+        assert!(seen.insert("a")); // "a" is new again after eviction
+        assert!(!seen.insert("c")); // "c" still remembered
+    }
+
+    #[test]
+    fn empty_id_always_passes() {
+        let seen = Seen::new(4);
+        assert!(seen.insert(""));
+        assert!(seen.insert(""));
+    }
+}

--- a/crates/heartwood-bridge/src/e2e.rs
+++ b/crates/heartwood-bridge/src/e2e.rs
@@ -1,0 +1,195 @@
+//! End-to-end test of the whole pump, without hardware.
+//!
+//! A NIP-46 request injected at a real (local) websocket relay flows through
+//! the **real** relay client, over a **real** socket-pair "serial" link to a
+//! simulated device, and the device's signed response is published back to the
+//! relay. This exercises the actual frame codec, `SerialSession`, relay
+//! subscribe/parse/publish, channel wiring and de-duplication together —
+//! everything except a physical ESP32 and a public relay.
+
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::dedup::Seen;
+use crate::frame::{
+    self, FRAME_TYPE_ENCRYPTED_REQUEST, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
+    FRAME_TYPE_PROVISION_LIST_RESPONSE, FRAME_TYPE_SESSION_ACK, FRAME_TYPE_SESSION_AUTH,
+    FRAME_TYPE_SIGN_ENVELOPE_RESPONSE,
+};
+use crate::relay::{run_relay, RequestJob};
+use crate::serial::SerialSession;
+
+// NIP-19 vector: this npub decodes to MASTER_HEX.
+const MASTER_NPUB: &str = "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6";
+const MASTER_HEX: &str = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d";
+const CLIENT_HEX: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const CIPHERTEXT: &str = "AgRequestCipherTextBase64==";
+const STAMP: u64 = 1_700_000_500;
+const BRIDGE_SECRET: [u8; 32] = [0x42; 32];
+
+fn hex32(s: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+        out[i] = u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16).unwrap();
+    }
+    out
+}
+
+/// The kind:24133 request the relay pushes to the bridge.
+fn request_event() -> Value {
+    json!({
+        "id": "ab".repeat(32),
+        "pubkey": CLIENT_HEX,
+        "created_at": 1_700_000_400u64,
+        "kind": 24133,
+        "tags": [["p", MASTER_HEX]],
+        "content": CIPHERTEXT,
+        "sig": "ee".repeat(64),
+    })
+}
+
+/// The signed kind:24133 response the simulated device returns (the signature
+/// is opaque to the bridge, which republishes the event verbatim).
+fn canned_signed_event() -> Value {
+    json!({
+        "id": "cc".repeat(32),
+        "pubkey": MASTER_HEX,
+        "created_at": STAMP,
+        "kind": 24133,
+        "tags": [["p", CLIENT_HEX]],
+        "content": "AgResponseCipherTextBase64==",
+        "sig": "dd".repeat(64),
+    })
+}
+
+/// Simulated device: speaks the real frame protocol over the socket pair.
+/// Answers SESSION_AUTH and PROVISION_LIST, then verifies one ENCRYPTED_REQUEST
+/// and returns the signed envelope.
+fn run_device_sim(mut io: UnixStream) {
+    loop {
+        let (ty, payload) = match frame::read_frame(&mut io, Duration::from_secs(15)) {
+            Ok(frame) => frame,
+            Err(_) => return, // host closed or timed out: we're done
+        };
+        match ty {
+            FRAME_TYPE_SESSION_AUTH => {
+                let status = if payload == BRIDGE_SECRET { 0x00 } else { 0x01 };
+                let _ = io.write_all(&frame::build_frame(FRAME_TYPE_SESSION_ACK, &[status]));
+            }
+            FRAME_TYPE_PROVISION_LIST => {
+                let infos = json!([{ "slot": 0, "label": "test", "mode": 1, "npub": MASTER_NPUB }]);
+                let _ = io.write_all(&frame::build_frame(
+                    FRAME_TYPE_PROVISION_LIST_RESPONSE,
+                    infos.to_string().as_bytes(),
+                ));
+            }
+            FRAME_TYPE_ENCRYPTED_REQUEST => {
+                // Verify the 0x10 payload the bridge built for us.
+                assert!(payload.len() >= 72, "0x10 payload too short");
+                assert_eq!(&payload[0..32], &hex32(MASTER_HEX), "master pubkey");
+                assert_eq!(&payload[32..64], &hex32(CLIENT_HEX), "client pubkey");
+                assert_eq!(
+                    u64::from_be_bytes(payload[64..72].try_into().unwrap()),
+                    STAMP,
+                    "created_at supplied by the host"
+                );
+                assert_eq!(&payload[72..], CIPHERTEXT.as_bytes(), "ciphertext verbatim");
+                let event = canned_signed_event().to_string();
+                let _ = io.write_all(&frame::build_frame(
+                    FRAME_TYPE_SIGN_ENVELOPE_RESPONSE,
+                    event.as_bytes(),
+                ));
+                return; // one request handled
+            }
+            _ => {
+                let _ = io.write_all(&frame::build_frame(FRAME_TYPE_NACK, &[]));
+            }
+        }
+    }
+}
+
+/// Minimal one-shot relay: accept a connection, expect the REQ, inject the
+/// request event, then report the event the bridge publishes back.
+async fn run_mock_relay(listener: TcpListener, published_tx: oneshot::Sender<Value>) {
+    let (stream, _) = listener.accept().await.expect("accept");
+    let ws = tokio_tungstenite::accept_async(stream).await.expect("ws handshake");
+    let (mut write, mut read) = ws.split();
+
+    // Wait for the subscription, then push the request.
+    while let Some(Ok(msg)) = read.next().await {
+        if let Message::Text(text) = msg {
+            let v: Value = serde_json::from_str(&text).unwrap();
+            if v[0] == "REQ" {
+                assert_eq!(v[2]["kinds"][0], 24133, "subscribes for kind 24133");
+                assert_eq!(v[2]["#p"][0], MASTER_HEX, "filters on our master");
+                let event = json!(["EVENT", "heartwood-bridge", request_event()]);
+                write.send(Message::Text(event.to_string())).await.unwrap();
+                break;
+            }
+        }
+    }
+
+    // Report the published signed event (client publish is ["EVENT", event]).
+    while let Some(Ok(msg)) = read.next().await {
+        if let Message::Text(text) = msg {
+            let v: Value = serde_json::from_str(&text).unwrap();
+            if v[0] == "EVENT" && v.as_array().map(Vec::len) == Some(2) {
+                let _ = published_tx.send(v[1].clone());
+                return;
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn relay_to_serial_to_device_e2e() {
+    // 1) Socket-pair stands in for the USB serial link.
+    let (host_io, device_io) = UnixStream::pair().expect("socketpair");
+    host_io.set_read_timeout(Some(Duration::from_millis(300))).unwrap();
+    device_io.set_read_timeout(Some(Duration::from_millis(300))).unwrap();
+
+    // 2) Device simulator on its own (blocking) thread.
+    let device = std::thread::spawn(move || run_device_sim(device_io));
+
+    // 3) Real session: authenticate and discover masters over the real codec.
+    let mut session = SerialSession::from_io(Box::new(host_io));
+    session.authenticate(&BRIDGE_SECRET).expect("authenticate");
+    let masters = session.list_master_pubkeys().expect("provision-list");
+    assert_eq!(masters, vec![MASTER_HEX.to_string()]);
+
+    // 4) Real local relay on an ephemeral port.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("ws://{}", listener.local_addr().unwrap());
+    let (published_tx, published_rx) = oneshot::channel();
+    tokio::spawn(run_mock_relay(listener, published_tx));
+
+    // 5) Wire the pump: a serial worker thread + the real relay client.
+    let (job_tx, mut job_rx) = mpsc::channel::<RequestJob>(8);
+    let (resp_tx, _) = broadcast::channel::<String>(8);
+    let resp_for_worker = resp_tx.clone();
+    let worker = std::thread::spawn(move || {
+        if let Some(job) = job_rx.blocking_recv() {
+            let payload = job.request.encrypted_request_payload(STAMP).unwrap();
+            let signed = session.sign(&payload).expect("sign").expect("not NACKed");
+            let _ = resp_for_worker.send(signed);
+        }
+    });
+    tokio::spawn(run_relay(url, masters, Seen::new(64), job_tx, resp_tx));
+
+    // 6) Assert the device's signed event was published back, verbatim.
+    let published = tokio::time::timeout(Duration::from_secs(10), published_rx)
+        .await
+        .expect("timed out waiting for the published event")
+        .expect("relay task dropped the sender");
+    assert_eq!(published, canned_signed_event());
+
+    let _ = device.join();
+    let _ = worker.join();
+}

--- a/crates/heartwood-bridge/src/event.rs
+++ b/crates/heartwood-bridge/src/event.rs
@@ -1,0 +1,179 @@
+//! NIP-46 request events and the `0x10` (ENCRYPTED_REQUEST) frame payload.
+//!
+//! The bridge does no cryptography. It extracts the three things the device
+//! needs from a relay event — the addressed master, the client (author) and
+//! the NIP-44 ciphertext — and lays them out for the firmware's inline signing
+//! path. The device decrypts, handles the request, re-encrypts and signs the
+//! response envelope itself.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+
+/// The Nostr event kind carrying NIP-46 requests (and the signed response
+/// envelope the device returns).
+pub const NIP46_KIND: u64 = 24133;
+
+/// A NIP-46 request addressed to one of our device masters, reduced to exactly
+/// what the firmware needs.
+#[derive(Debug, Clone)]
+pub struct Nip46Request {
+    /// Event id (hex) — used only for cross-relay de-duplication.
+    pub id: String,
+    /// The NIP-46 client (event author), x-only pubkey hex.
+    pub client_pubkey_hex: String,
+    /// The addressed device master (`p` tag), x-only pubkey hex.
+    pub master_pubkey_hex: String,
+    /// NIP-44 ciphertext (base64), forwarded to the device verbatim.
+    pub content: String,
+}
+
+impl Nip46Request {
+    /// Parse and validate a relay event JSON.
+    ///
+    /// Returns `Ok(None)` when the event is simply not a NIP-46 request for a
+    /// master we hold (silently ignored), and `Err` only for input that claims
+    /// to be one but is malformed.
+    pub fn from_event(event: &Value, known_masters: &[String]) -> Result<Option<Self>> {
+        if event.get("kind").and_then(Value::as_u64) != Some(NIP46_KIND) {
+            return Ok(None);
+        }
+
+        // Must be addressed (`p` tag) to one of our masters, else not ours.
+        let master_pubkey_hex = match find_master_p_tag(event, known_masters) {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+
+        let client = event
+            .get("pubkey")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("event missing pubkey"))?;
+        if !is_hex32(client) {
+            bail!("event pubkey is not 32-byte hex");
+        }
+        let content = event
+            .get("content")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("event missing content"))?
+            .to_string();
+        let id = event
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        Ok(Some(Self {
+            id,
+            client_pubkey_hex: client.to_string(),
+            master_pubkey_hex,
+            content,
+        }))
+    }
+
+    /// Build the `0x10` ENCRYPTED_REQUEST payload:
+    /// `[master_pk 32][client_pk 32][created_at u64-be 8][ciphertext bytes…]`.
+    ///
+    /// `created_at` becomes the device's *response* envelope timestamp (the
+    /// firmware has no reliable clock), so callers pass the current unix time.
+    pub fn encrypted_request_payload(&self, created_at: u64) -> Result<Vec<u8>> {
+        let master = hex32(&self.master_pubkey_hex).context("master pubkey")?;
+        let client = hex32(&self.client_pubkey_hex).context("client pubkey")?;
+        let mut payload = Vec::with_capacity(32 + 32 + 8 + self.content.len());
+        payload.extend_from_slice(&master);
+        payload.extend_from_slice(&client);
+        payload.extend_from_slice(&created_at.to_be_bytes());
+        payload.extend_from_slice(self.content.as_bytes());
+        Ok(payload)
+    }
+}
+
+/// Find a `p` tag whose value is one of our masters.
+fn find_master_p_tag(event: &Value, known_masters: &[String]) -> Option<String> {
+    event
+        .get("tags")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_array)
+        .find_map(|tag| {
+            let name = tag.first()?.as_str()?;
+            let val = tag.get(1)?.as_str()?;
+            (name == "p" && known_masters.iter().any(|m| m == val)).then(|| val.to_string())
+        })
+}
+
+fn is_hex32(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn hex32(s: &str) -> Result<[u8; 32]> {
+    if s.len() != 64 {
+        bail!("expected 64 hex chars, got {}", s.len());
+    }
+    let mut out = [0u8; 32];
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+        let hi = (chunk[0] as char).to_digit(16).ok_or_else(|| anyhow!("bad hex digit"))?;
+        let lo = (chunk[1] as char).to_digit(16).ok_or_else(|| anyhow!("bad hex digit"))?;
+        out[i] = ((hi << 4) | lo) as u8;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const MASTER: &str = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d";
+    const CLIENT: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+
+    fn req_event() -> Value {
+        json!({
+            "id": "aa".repeat(32),
+            "pubkey": CLIENT,
+            "created_at": 1_700_000_000u64,
+            "kind": 24133,
+            "tags": [["p", MASTER]],
+            "content": "AgIc1pha+base64ciphertext==",
+            "sig": "ff".repeat(64),
+        })
+    }
+
+    #[test]
+    fn parses_request_for_known_master() {
+        let masters = vec![MASTER.to_string()];
+        let req = Nip46Request::from_event(&req_event(), &masters).unwrap().unwrap();
+        assert_eq!(req.master_pubkey_hex, MASTER);
+        assert_eq!(req.client_pubkey_hex, CLIENT);
+        assert_eq!(req.content, "AgIc1pha+base64ciphertext==");
+        assert_eq!(req.id, "aa".repeat(32));
+    }
+
+    #[test]
+    fn ignores_other_kinds() {
+        let mut e = req_event();
+        e["kind"] = json!(1);
+        let masters = vec![MASTER.to_string()];
+        assert!(Nip46Request::from_event(&e, &masters).unwrap().is_none());
+    }
+
+    #[test]
+    fn ignores_events_for_other_masters() {
+        let masters = vec!["bb".repeat(32)];
+        assert!(Nip46Request::from_event(&req_event(), &masters).unwrap().is_none());
+    }
+
+    #[test]
+    fn payload_layout_is_correct() {
+        let masters = vec![MASTER.to_string()];
+        let req = Nip46Request::from_event(&req_event(), &masters).unwrap().unwrap();
+        let created_at = 1_700_000_123u64;
+        let p = req.encrypted_request_payload(created_at).unwrap();
+
+        assert_eq!(p.len(), 32 + 32 + 8 + req.content.len());
+        assert_eq!(&p[0..32], &hex32(MASTER).unwrap());
+        assert_eq!(&p[32..64], &hex32(CLIENT).unwrap());
+        assert_eq!(u64::from_be_bytes(p[64..72].try_into().unwrap()), created_at);
+        assert_eq!(&p[72..], req.content.as_bytes());
+    }
+}

--- a/crates/heartwood-bridge/src/event.rs
+++ b/crates/heartwood-bridge/src/event.rs
@@ -56,18 +56,9 @@ impl Nip46Request {
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow!("event missing content"))?
             .to_string();
-        let id = event
-            .get("id")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string();
+        let id = event.get("id").and_then(Value::as_str).unwrap_or_default().to_string();
 
-        Ok(Some(Self {
-            id,
-            client_pubkey_hex: client.to_string(),
-            master_pubkey_hex,
-            content,
-        }))
+        Ok(Some(Self { id, client_pubkey_hex: client.to_string(), master_pubkey_hex, content }))
     }
 
     /// Build the `0x10` ENCRYPTED_REQUEST payload:

--- a/crates/heartwood-bridge/src/frame.rs
+++ b/crates/heartwood-bridge/src/frame.rs
@@ -67,7 +67,8 @@ pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>)> {
     if buf.len() != total {
         bail!("frame length mismatch: header says {total}, got {}", buf.len());
     }
-    let expected = u32::from_be_bytes([buf[total - 4], buf[total - 3], buf[total - 2], buf[total - 1]]);
+    let expected =
+        u32::from_be_bytes([buf[total - 4], buf[total - 3], buf[total - 2], buf[total - 1]]);
     // CRC covers type + length + payload, but NOT the 2 magic bytes.
     let actual = crc32fast::hash(&buf[FRAME_MAGIC.len()..total - 4]);
     if actual != expected {
@@ -80,7 +81,10 @@ pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>)> {
 ///
 /// Bytes are accumulated and resynchronised on the magic preamble, so stray
 /// bytes before a frame (e.g. a boot banner) are skipped rather than fatal.
-pub fn read_frame<R: std::io::Read + ?Sized>(port: &mut R, timeout: Duration) -> Result<(u8, Vec<u8>)> {
+pub fn read_frame<R: std::io::Read + ?Sized>(
+    port: &mut R,
+    timeout: Duration,
+) -> Result<(u8, Vec<u8>)> {
     let deadline = Instant::now() + timeout;
     let mut buf: Vec<u8> = Vec::with_capacity(128);
 

--- a/crates/heartwood-bridge/src/frame.rs
+++ b/crates/heartwood-bridge/src/frame.rs
@@ -80,7 +80,7 @@ pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>)> {
 ///
 /// Bytes are accumulated and resynchronised on the magic preamble, so stray
 /// bytes before a frame (e.g. a boot banner) are skipped rather than fatal.
-pub fn read_frame(port: &mut dyn serialport::SerialPort, timeout: Duration) -> Result<(u8, Vec<u8>)> {
+pub fn read_frame<R: std::io::Read + ?Sized>(port: &mut R, timeout: Duration) -> Result<(u8, Vec<u8>)> {
     let deadline = Instant::now() + timeout;
     let mut buf: Vec<u8> = Vec::with_capacity(128);
 
@@ -93,7 +93,14 @@ pub fn read_frame(port: &mut dyn serialport::SerialPort, timeout: Duration) -> R
         match std::io::Read::read(port, &mut byte) {
             Ok(1) => buf.push(byte[0]),
             Ok(_) => continue,
-            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
+            // A read timeout (serial ports) or WouldBlock (sockets with a read
+            // timeout) just means "nothing yet" — keep waiting until the deadline.
+            Err(ref e)
+                if e.kind() == std::io::ErrorKind::TimedOut
+                    || e.kind() == std::io::ErrorKind::WouldBlock =>
+            {
+                continue
+            }
             Err(e) => return Err(anyhow::Error::new(e).context("serial read error")),
         }
 

--- a/crates/heartwood-bridge/src/frame.rs
+++ b/crates/heartwood-bridge/src/frame.rs
@@ -1,0 +1,179 @@
+//! Binary serial frame protocol shared with the Heartwood device firmware.
+//!
+//! Wire format (big-endian lengths, IEEE CRC-32):
+//!
+//! ```text
+//! [magic "HW" (2)] [type (1)] [len u16 (2)] [payload (len)] [crc32 (4)]
+//! ```
+//!
+//! The CRC covers the **type, length and payload only — NOT the magic
+//! preamble**, matching the firmware in `heartwood-esp32`
+//! (`common/src/frame.rs`). (Note: `heartwood-device`'s in-file web serial
+//! codec hashes *including* the magic, which is incompatible with the device;
+//! this codec follows the firmware, which is authoritative.) The frame-type
+//! constants below are a subset of `heartwood-esp32`'s `common/src/types.rs`.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Result};
+
+/// Frame preamble: ASCII "HW".
+pub const FRAME_MAGIC: [u8; 2] = [0x48, 0x57];
+
+/// Header before the payload: magic(2) + type(1) + len(2).
+pub const HEADER_LEN: usize = 2 + 1 + 2;
+
+/// Fixed overhead around a payload: header(5) + crc(4).
+pub const FRAME_OVERHEAD: usize = HEADER_LEN + 4;
+
+// --- Frame types the bridge uses (subset of the firmware's full set) ---
+pub const FRAME_TYPE_NACK: u8 = 0x15;
+pub const FRAME_TYPE_PROVISION_LIST: u8 = 0x05;
+pub const FRAME_TYPE_PROVISION_LIST_RESPONSE: u8 = 0x07;
+pub const FRAME_TYPE_ENCRYPTED_REQUEST: u8 = 0x10;
+pub const FRAME_TYPE_SESSION_AUTH: u8 = 0x21;
+pub const FRAME_TYPE_SESSION_ACK: u8 = 0x22;
+pub const FRAME_TYPE_SIGN_ENVELOPE_RESPONSE: u8 = 0x35;
+pub const FRAME_TYPE_FIRMWARE_INFO: u8 = 0x59;
+pub const FRAME_TYPE_FIRMWARE_INFO_RESPONSE: u8 = 0x5A;
+
+/// Build a framed serial message ready to write to the port.
+pub fn build_frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(FRAME_OVERHEAD + payload.len());
+    frame.extend_from_slice(&FRAME_MAGIC);
+    frame.push(frame_type);
+    frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    frame.extend_from_slice(payload);
+    // CRC covers type + length + payload, but NOT the 2 magic bytes.
+    let checksum = crc32fast::hash(&frame[FRAME_MAGIC.len()..]);
+    frame.extend_from_slice(&checksum.to_be_bytes());
+    frame
+}
+
+/// Validate and extract a single, complete frame that occupies exactly `buf`.
+///
+/// `buf` must start at the magic bytes and contain one whole frame (the caller
+/// computes the length from the header). Returns `(frame_type, payload)`.
+pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>)> {
+    if buf.len() < FRAME_OVERHEAD {
+        bail!("frame buffer too short ({} bytes)", buf.len());
+    }
+    if buf[0] != FRAME_MAGIC[0] || buf[1] != FRAME_MAGIC[1] {
+        bail!("bad frame magic");
+    }
+    let frame_type = buf[2];
+    let payload_len = u16::from_be_bytes([buf[3], buf[4]]) as usize;
+    let total = FRAME_OVERHEAD + payload_len;
+    if buf.len() != total {
+        bail!("frame length mismatch: header says {total}, got {}", buf.len());
+    }
+    let expected = u32::from_be_bytes([buf[total - 4], buf[total - 3], buf[total - 2], buf[total - 1]]);
+    // CRC covers type + length + payload, but NOT the 2 magic bytes.
+    let actual = crc32fast::hash(&buf[FRAME_MAGIC.len()..total - 4]);
+    if actual != expected {
+        bail!("CRC mismatch (expected {expected:#010x}, got {actual:#010x})");
+    }
+    Ok((frame_type, buf[HEADER_LEN..total - 4].to_vec()))
+}
+
+/// Read one complete frame from the serial port, blocking up to `timeout`.
+///
+/// Bytes are accumulated and resynchronised on the magic preamble, so stray
+/// bytes before a frame (e.g. a boot banner) are skipped rather than fatal.
+pub fn read_frame(port: &mut dyn serialport::SerialPort, timeout: Duration) -> Result<(u8, Vec<u8>)> {
+    let deadline = Instant::now() + timeout;
+    let mut buf: Vec<u8> = Vec::with_capacity(128);
+
+    loop {
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for a frame from the device");
+        }
+
+        let mut byte = [0u8; 1];
+        match std::io::Read::read(port, &mut byte) {
+            Ok(1) => buf.push(byte[0]),
+            Ok(_) => continue,
+            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
+            Err(e) => return Err(anyhow::Error::new(e).context("serial read error")),
+        }
+
+        // Need at least the header to know the total length.
+        if buf.len() < FRAME_OVERHEAD {
+            continue;
+        }
+        // Resynchronise on the magic preamble.
+        if buf[0] != FRAME_MAGIC[0] || buf[1] != FRAME_MAGIC[1] {
+            buf.remove(0);
+            continue;
+        }
+        let payload_len = u16::from_be_bytes([buf[3], buf[4]]) as usize;
+        let total = FRAME_OVERHEAD + payload_len;
+        if buf.len() < total {
+            continue;
+        }
+        return parse_complete(&buf[..total]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_then_parse_round_trips() {
+        let payload = b"hello device";
+        let frame = build_frame(FRAME_TYPE_ENCRYPTED_REQUEST, payload);
+        // magic(2)+type(1)+len(2)+payload(12)+crc(4)
+        assert_eq!(frame.len(), FRAME_OVERHEAD + payload.len());
+        let (ty, got) = parse_complete(&frame).unwrap();
+        assert_eq!(ty, FRAME_TYPE_ENCRYPTED_REQUEST);
+        assert_eq!(got, payload);
+    }
+
+    #[test]
+    fn empty_payload_round_trips() {
+        let frame = build_frame(FRAME_TYPE_PROVISION_LIST, &[]);
+        let (ty, got) = parse_complete(&frame).unwrap();
+        assert_eq!(ty, FRAME_TYPE_PROVISION_LIST);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn corrupt_payload_fails_crc() {
+        let mut frame = build_frame(FRAME_TYPE_NACK, b"abc");
+        let mid = 6; // somewhere in the payload
+        frame[mid] ^= 0xff;
+        assert!(parse_complete(&frame).is_err());
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        let mut frame = build_frame(FRAME_TYPE_NACK, b"x");
+        frame[0] = 0x00;
+        assert!(parse_complete(&frame).is_err());
+    }
+
+    #[test]
+    fn crc_excludes_magic_matching_firmware() {
+        // The firmware (heartwood-esp32 common/src/frame.rs) hashes
+        // type + length + payload, NOT the magic preamble. Pin that exact
+        // scheme so the bridge stays wire-compatible with real hardware.
+        let frame_type = FRAME_TYPE_ENCRYPTED_REQUEST;
+        let payload = b"abc";
+        let frame = build_frame(frame_type, payload);
+
+        let total = frame.len();
+        let emitted = u32::from_be_bytes([
+            frame[total - 4],
+            frame[total - 3],
+            frame[total - 2],
+            frame[total - 1],
+        ]);
+
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&[frame_type]);
+        hasher.update(&(payload.len() as u16).to_be_bytes());
+        hasher.update(payload);
+        assert_eq!(emitted, hasher.finalize(), "CRC must exclude the magic bytes");
+    }
+}

--- a/crates/heartwood-bridge/src/main.rs
+++ b/crates/heartwood-bridge/src/main.rs
@@ -1,0 +1,114 @@
+//! heartwood-bridge — relay-to-serial signing bridge.
+//!
+//! A sidecar daemon for HSM-mode Heartwood instances. It connects the Nostr
+//! relays to a USB-tethered signing device (ESP32/ESP8266) so a device with no
+//! network of its own can still answer NIP-46 requests: the bridge is its
+//! relay connection, and nothing more. All cryptography — NIP-44 decryption,
+//! request handling, response signing — happens on the device, inline, via the
+//! firmware's `ENCRYPTED_REQUEST` (0x10) → `SIGN_ENVELOPE_RESPONSE` (0x35)
+//! path. The bridge never holds key material and never sees plaintext.
+//!
+//! See `docs/2026-06-25-relay-serial-bridge.md`.
+
+mod bridge;
+mod config;
+mod dedup;
+mod event;
+mod frame;
+mod npub;
+mod relay;
+mod serial;
+
+use anyhow::{Context, Result};
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+/// Request event ids remembered for cross-relay de-duplication.
+const SEEN_CAPACITY: usize = 4096;
+/// Pending signing jobs queued for the (single, sequential) device.
+const JOB_QUEUE: usize = 64;
+/// Buffered signed responses awaiting publication to each relay.
+const RESP_QUEUE: usize = 256;
+
+/// Current unix time in seconds. The device has no reliable clock, so the
+/// bridge stamps the `created_at` the firmware writes into response envelopes.
+pub fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    tracing::info!("heartwood-bridge starting");
+
+    let config = config::Config::load()?;
+    tracing::info!(
+        "data dir {}, serial {}, relays [{}]",
+        config.data_dir.display(),
+        config.serial_port,
+        config.relays.join(", ")
+    );
+    let relays = config.relays.clone();
+
+    let (job_tx, job_rx) = mpsc::channel::<relay::RequestJob>(JOB_QUEUE);
+    let (resp_tx, _) = broadcast::channel::<String>(RESP_QUEUE);
+    let (masters_tx, masters_rx) = oneshot::channel::<Vec<String>>();
+
+    // The serial worker owns the port on its own (blocking) thread.
+    let _worker = bridge::spawn_serial_worker(config, job_rx, resp_tx.clone(), masters_tx);
+
+    // Wait for the device's master pubkeys before subscribing to anything —
+    // but stay responsive to shutdown if the device never shows up.
+    let masters = tokio::select! {
+        result = masters_rx => result.context("serial worker exited before reporting device masters")?,
+        _ = shutdown_signal() => {
+            tracing::info!("shutdown before the device was ready; exiting");
+            return Ok(());
+        }
+    };
+
+    let seen = dedup::Seen::new(SEEN_CAPACITY);
+    for url in relays {
+        tokio::spawn(relay::run_relay(
+            url,
+            masters.clone(),
+            seen.clone(),
+            job_tx.clone(),
+            resp_tx.clone(),
+        ));
+    }
+    // Drop our spare job sender so the count reflects only the relay tasks.
+    drop(job_tx);
+
+    tracing::info!("bridge running for {} master(s); awaiting requests", masters.len());
+
+    shutdown_signal().await;
+    tracing::info!("shutdown signal received; exiting");
+    Ok(())
+}
+
+/// Resolve on SIGTERM (systemd stop) or Ctrl-C.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("cannot install SIGTERM handler: {e}; using Ctrl-C only");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/crates/heartwood-bridge/src/main.rs
+++ b/crates/heartwood-bridge/src/main.rs
@@ -19,6 +19,9 @@ mod npub;
 mod relay;
 mod serial;
 
+#[cfg(all(test, unix))]
+mod e2e;
+
 use anyhow::{Context, Result};
 use tokio::sync::{broadcast, mpsc, oneshot};
 

--- a/crates/heartwood-bridge/src/npub.rs
+++ b/crates/heartwood-bridge/src/npub.rs
@@ -1,0 +1,64 @@
+//! NIP-19 `npub` decoding.
+//!
+//! The bridge never holds key material, but it must know the device's master
+//! *public* key to build the relay subscription filter (`#p`) and the
+//! per-request `0x10` frame. The device reports its identities as bech32
+//! `npub1…` strings over `PROVISION_LIST`; this module turns one back into the
+//! 32-byte x-only public key, hex-encoded as Nostr events carry it.
+
+use anyhow::{bail, Context, Result};
+
+/// Decode a bech32 `npub1…` string into its 32-byte x-only public key,
+/// returned as lowercase hex (64 chars).
+pub fn npub_to_hex(npub: &str) -> Result<String> {
+    let (hrp, data) = bech32::decode(npub).context("value is not valid bech32")?;
+    if hrp.as_str() != "npub" {
+        bail!("expected an 'npub' but the hrp was '{}'", hrp.as_str());
+    }
+    if data.len() != 32 {
+        bail!("npub decodes to {} bytes, expected 32", data.len());
+    }
+    Ok(hex_encode(&data))
+}
+
+/// Lowercase hex encoding (no external dependency for such a small helper).
+pub fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Canonical NIP-19 test vector.
+    const NPUB: &str = "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6";
+    const HEX: &str = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d";
+
+    #[test]
+    fn decodes_nip19_vector() {
+        assert_eq!(npub_to_hex(NPUB).unwrap(), HEX);
+    }
+
+    #[test]
+    fn rejects_non_npub_hrp() {
+        // A valid bech32 string with the wrong hrp (an nsec) must be refused.
+        let nsec = "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5";
+        assert!(npub_to_hex(nsec).is_err());
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(npub_to_hex("not-an-npub").is_err());
+    }
+
+    #[test]
+    fn hex_encode_is_lowercase_and_padded() {
+        assert_eq!(hex_encode(&[0x00, 0x0f, 0xa0, 0xff]), "000fa0ff");
+    }
+}

--- a/crates/heartwood-bridge/src/relay.rs
+++ b/crates/heartwood-bridge/src/relay.rs
@@ -1,0 +1,174 @@
+//! Per-relay websocket task.
+//!
+//! Subscribes for NIP-46 requests addressed to our masters, forwards each
+//! (de-duplicated) request to the serial worker, and publishes the device's
+//! signed response events back to the relay. Reconnects with capped backoff.
+//!
+//! NIP-42 AUTH is intentionally unsupported: the bridge holds no key, so it
+//! cannot sign an auth challenge. Relays that demand AUTH for kind-24133 are
+//! out of scope (the device-direct wifi-standalone tier is the answer there).
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::sync::{broadcast, mpsc};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::dedup::Seen;
+use crate::event::{Nip46Request, NIP46_KIND};
+
+/// A unit of work for the serial worker.
+#[derive(Debug, Clone)]
+pub struct RequestJob {
+    pub request: Nip46Request,
+}
+
+const SUBSCRIPTION_ID: &str = "heartwood-bridge";
+const MIN_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Run one relay connection forever, reconnecting with capped backoff.
+pub async fn run_relay(
+    url: String,
+    masters: Vec<String>,
+    seen: Seen,
+    job_tx: mpsc::Sender<RequestJob>,
+    resp_tx: broadcast::Sender<String>,
+) {
+    let mut backoff = MIN_BACKOFF;
+    loop {
+        match connect_and_serve(&url, &masters, &seen, &job_tx, &resp_tx).await {
+            Ok(()) => {
+                tracing::info!(relay = %url, "connection closed; reconnecting");
+                backoff = MIN_BACKOFF;
+            }
+            Err(e) => {
+                tracing::warn!(relay = %url, "relay error: {e:#}; retry in {}s", backoff.as_secs());
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(MAX_BACKOFF);
+    }
+}
+
+async fn connect_and_serve(
+    url: &str,
+    masters: &[String],
+    seen: &Seen,
+    job_tx: &mpsc::Sender<RequestJob>,
+    resp_tx: &broadcast::Sender<String>,
+) -> Result<()> {
+    let (ws, _) = tokio_tungstenite::connect_async(url)
+        .await
+        .with_context(|| format!("connecting to {url}"))?;
+    tracing::info!(relay = %url, "connected");
+    let (mut write, mut read) = ws.split();
+
+    // Subscribe to live NIP-46 requests addressed to any of our masters.
+    let since = crate::now_unix();
+    let req = json!(["REQ", SUBSCRIPTION_ID, {
+        "kinds": [NIP46_KIND],
+        "#p": masters,
+        "since": since,
+    }]);
+    write.send(Message::Text(req.to_string())).await.context("sending REQ")?;
+
+    let mut resp_rx = resp_tx.subscribe();
+
+    loop {
+        tokio::select! {
+            // Inbound from the relay.
+            incoming = read.next() => {
+                let msg = match incoming {
+                    Some(m) => m.context("relay read failed")?,
+                    None => return Ok(()), // stream ended
+                };
+                match msg {
+                    Message::Text(text) => handle_relay_message(&text, url, masters, seen, job_tx).await,
+                    Message::Ping(payload) => { let _ = write.send(Message::Pong(payload)).await; }
+                    Message::Close(_) => return Ok(()),
+                    _ => {}
+                }
+            }
+            // Outbound: a freshly-signed response to publish everywhere.
+            broadcasted = resp_rx.recv() => {
+                match broadcasted {
+                    Ok(event_json) => {
+                        let publish = format!("[\"EVENT\",{event_json}]");
+                        write.send(Message::Text(publish)).await.context("publishing event")?;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(relay = %url, "publish lagged; dropped {n} response(s)");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                }
+            }
+        }
+    }
+}
+
+async fn handle_relay_message(
+    text: &str,
+    url: &str,
+    masters: &[String],
+    seen: &Seen,
+    job_tx: &mpsc::Sender<RequestJob>,
+) {
+    let parsed: Value = match serde_json::from_str(text) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let arr = match parsed.as_array() {
+        Some(a) if !a.is_empty() => a,
+        _ => return,
+    };
+
+    match arr[0].as_str() {
+        // ["EVENT", sub_id, event]
+        Some("EVENT") => {
+            let Some(event) = arr.get(2) else { return };
+            match Nip46Request::from_event(event, masters) {
+                Ok(Some(request)) => {
+                    if seen.insert(&request.id) {
+                        tracing::info!(
+                            relay = %url,
+                            client = %short(&request.client_pubkey_hex),
+                            "request received"
+                        );
+                        if let Err(e) = job_tx.send(RequestJob { request }).await {
+                            tracing::error!("serial worker is gone: {e}");
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => tracing::debug!(relay = %url, "ignoring malformed event: {e}"),
+            }
+        }
+        // ["OK", id, accepted, message]
+        Some("OK") => {
+            let accepted = arr.get(2).and_then(Value::as_bool).unwrap_or(false);
+            if !accepted {
+                let msg = arr.get(3).and_then(Value::as_str).unwrap_or("");
+                tracing::warn!(relay = %url, "relay rejected publish: {msg}");
+            }
+        }
+        // ["CLOSED", sub_id, message]
+        Some("CLOSED") => {
+            let msg = arr.get(2).and_then(Value::as_str).unwrap_or("");
+            tracing::warn!(relay = %url, "subscription closed by relay: {msg}");
+        }
+        // ["NOTICE", message]
+        Some("NOTICE") => {
+            let msg = arr.get(1).and_then(Value::as_str).unwrap_or("");
+            tracing::debug!(relay = %url, "notice: {msg}");
+        }
+        _ => {} // EOSE and anything else: ignore
+    }
+}
+
+/// First 12 hex chars, for compact logging.
+fn short(hex: &str) -> &str {
+    &hex[..hex.len().min(12)]
+}

--- a/crates/heartwood-bridge/src/serial.rs
+++ b/crates/heartwood-bridge/src/serial.rs
@@ -27,8 +27,31 @@ const CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
 /// the device plenty of time before giving up on a response.
 const SIGN_TIMEOUT: Duration = Duration::from_secs(45);
 
+/// Anything the session can speak over: a real serial port, or — in tests — an
+/// in-process socket pair. Blanket-implemented for every suitable byte stream.
+pub trait ReadWrite: std::io::Read + std::io::Write + Send {}
+impl<T: std::io::Read + std::io::Write + Send + ?Sized> ReadWrite for T {}
+
+/// Adapter letting a boxed `serialport` port (which cannot be coerced directly
+/// to `Box<dyn ReadWrite>`) back a session.
+struct SerialPortIo(Box<dyn serialport::SerialPort>);
+
+impl std::io::Read for SerialPortIo {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+impl std::io::Write for SerialPortIo {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
 pub struct SerialSession {
-    port: Box<dyn serialport::SerialPort>,
+    io: Box<dyn ReadWrite>,
 }
 
 impl SerialSession {
@@ -38,13 +61,20 @@ impl SerialSession {
             .timeout(READ_TIMEOUT)
             .open()
             .with_context(|| format!("opening serial port {port_path}"))?;
-        Ok(Self { port })
+        Ok(Self { io: Box::new(SerialPortIo(port)) })
+    }
+
+    /// Build a session over an arbitrary byte stream — tests drive it over a
+    /// `UnixStream` pair instead of real hardware.
+    #[cfg(test)]
+    pub fn from_io(io: Box<dyn ReadWrite>) -> Self {
+        Self { io }
     }
 
     fn transact(&mut self, frame_type: u8, payload: &[u8], timeout: Duration) -> Result<(u8, Vec<u8>)> {
         let frame = frame::build_frame(frame_type, payload);
-        std::io::Write::write_all(&mut *self.port, &frame).context("serial write failed")?;
-        frame::read_frame(&mut *self.port, timeout)
+        std::io::Write::write_all(&mut *self.io, &frame).context("serial write failed")?;
+        frame::read_frame(&mut *self.io, timeout)
     }
 
     /// `SESSION_AUTH` (0x21): present the 32-byte shared secret and expect

--- a/crates/heartwood-bridge/src/serial.rs
+++ b/crates/heartwood-bridge/src/serial.rs
@@ -71,7 +71,12 @@ impl SerialSession {
         Self { io }
     }
 
-    fn transact(&mut self, frame_type: u8, payload: &[u8], timeout: Duration) -> Result<(u8, Vec<u8>)> {
+    fn transact(
+        &mut self,
+        frame_type: u8,
+        payload: &[u8],
+        timeout: Duration,
+    ) -> Result<(u8, Vec<u8>)> {
         let frame = frame::build_frame(frame_type, payload);
         std::io::Write::write_all(&mut *self.io, &frame).context("serial write failed")?;
         frame::read_frame(&mut *self.io, timeout)
@@ -99,7 +104,8 @@ impl SerialSession {
         if ty != FRAME_TYPE_PROVISION_LIST_RESPONSE {
             bail!("expected PROVISION_LIST_RESPONSE (0x07), got {ty:#04x}");
         }
-        let infos: Vec<Value> = serde_json::from_slice(&payload).context("parsing provision-list JSON")?;
+        let infos: Vec<Value> =
+            serde_json::from_slice(&payload).context("parsing provision-list JSON")?;
         let mut pubkeys = Vec::new();
         for info in infos {
             if let Some(npub_str) = info.get("npub").and_then(Value::as_str) {
@@ -128,11 +134,8 @@ impl SerialSession {
     /// the fully-signed response event JSON (publish verbatim), or `None` if
     /// the device NACKed (unknown master, decrypt failure, or policy denial).
     pub fn sign(&mut self, encrypted_request_payload: &[u8]) -> Result<Option<String>> {
-        let (ty, resp) = self.transact(
-            FRAME_TYPE_ENCRYPTED_REQUEST,
-            encrypted_request_payload,
-            SIGN_TIMEOUT,
-        )?;
+        let (ty, resp) =
+            self.transact(FRAME_TYPE_ENCRYPTED_REQUEST, encrypted_request_payload, SIGN_TIMEOUT)?;
         match ty {
             FRAME_TYPE_SIGN_ENVELOPE_RESPONSE => {
                 let json = String::from_utf8(resp).context("response event was not UTF-8")?;

--- a/crates/heartwood-bridge/src/serial.rs
+++ b/crates/heartwood-bridge/src/serial.rs
@@ -1,0 +1,115 @@
+//! Blocking serial session to the device.
+//!
+//! Opens the port, authenticates the bridge session, discovers the master
+//! identities, and runs signing requests through the firmware's inline
+//! `ENCRYPTED_REQUEST` (`0x10`) → `SIGN_ENVELOPE_RESPONSE` (`0x35`) path. All
+//! cryptography happens on the device; this is a transport.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+use crate::frame::{
+    self, FRAME_TYPE_ENCRYPTED_REQUEST, FRAME_TYPE_FIRMWARE_INFO,
+    FRAME_TYPE_FIRMWARE_INFO_RESPONSE, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
+    FRAME_TYPE_PROVISION_LIST_RESPONSE, FRAME_TYPE_SESSION_ACK, FRAME_TYPE_SESSION_AUTH,
+    FRAME_TYPE_SIGN_ENVELOPE_RESPONSE,
+};
+use crate::npub;
+
+const BAUD: u32 = 115_200;
+/// Per-`read` byte timeout used while assembling a frame.
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+/// Control frames (auth, provision-list, firmware-info) answer immediately.
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(5);
+/// Signing may block on a physical button press (TOFU "ask" policy), so allow
+/// the device plenty of time before giving up on a response.
+const SIGN_TIMEOUT: Duration = Duration::from_secs(45);
+
+pub struct SerialSession {
+    port: Box<dyn serialport::SerialPort>,
+}
+
+impl SerialSession {
+    /// Open the serial port. Does not authenticate.
+    pub fn open(port_path: &str) -> Result<Self> {
+        let port = serialport::new(port_path, BAUD)
+            .timeout(READ_TIMEOUT)
+            .open()
+            .with_context(|| format!("opening serial port {port_path}"))?;
+        Ok(Self { port })
+    }
+
+    fn transact(&mut self, frame_type: u8, payload: &[u8], timeout: Duration) -> Result<(u8, Vec<u8>)> {
+        let frame = frame::build_frame(frame_type, payload);
+        std::io::Write::write_all(&mut *self.port, &frame).context("serial write failed")?;
+        frame::read_frame(&mut *self.port, timeout)
+    }
+
+    /// `SESSION_AUTH` (0x21): present the 32-byte shared secret and expect
+    /// `SESSION_ACK` (0x22) with status `0x00`.
+    pub fn authenticate(&mut self, secret: &[u8; 32]) -> Result<()> {
+        let (ty, status) = self.transact(FRAME_TYPE_SESSION_AUTH, secret, CONTROL_TIMEOUT)?;
+        if ty != FRAME_TYPE_SESSION_ACK {
+            bail!("expected SESSION_ACK (0x22), got {ty:#04x}");
+        }
+        match status.first().copied() {
+            Some(0x00) => Ok(()),
+            Some(0x01) => bail!("device rejected the bridge secret (wrong secret)"),
+            Some(0x02) => bail!("device has no bridge secret provisioned — set one over USB first"),
+            other => bail!("unexpected SESSION_ACK status {other:?}"),
+        }
+    }
+
+    /// `PROVISION_LIST` (0x05 → 0x07): discover provisioned masters. Returns
+    /// their x-only public keys as hex (decoded from the reported npubs).
+    pub fn list_master_pubkeys(&mut self) -> Result<Vec<String>> {
+        let (ty, payload) = self.transact(FRAME_TYPE_PROVISION_LIST, &[], CONTROL_TIMEOUT)?;
+        if ty != FRAME_TYPE_PROVISION_LIST_RESPONSE {
+            bail!("expected PROVISION_LIST_RESPONSE (0x07), got {ty:#04x}");
+        }
+        let infos: Vec<Value> = serde_json::from_slice(&payload).context("parsing provision-list JSON")?;
+        let mut pubkeys = Vec::new();
+        for info in infos {
+            if let Some(npub_str) = info.get("npub").and_then(Value::as_str) {
+                match npub::npub_to_hex(npub_str) {
+                    Ok(hex) => pubkeys.push(hex),
+                    Err(e) => tracing::warn!("skipping un-decodable npub {npub_str}: {e}"),
+                }
+            }
+        }
+        if pubkeys.is_empty() {
+            bail!("device reported no provisioned masters");
+        }
+        Ok(pubkeys)
+    }
+
+    /// `FIRMWARE_INFO` (0x59 → 0x5A): read-only version/board query.
+    pub fn firmware_info(&mut self) -> Result<Value> {
+        let (ty, payload) = self.transact(FRAME_TYPE_FIRMWARE_INFO, &[], CONTROL_TIMEOUT)?;
+        if ty != FRAME_TYPE_FIRMWARE_INFO_RESPONSE {
+            bail!("expected FIRMWARE_INFO_RESPONSE (0x5A), got {ty:#04x}");
+        }
+        serde_json::from_slice(&payload).context("parsing firmware-info JSON")
+    }
+
+    /// Run a NIP-46 request through the device's inline signing path. Returns
+    /// the fully-signed response event JSON (publish verbatim), or `None` if
+    /// the device NACKed (unknown master, decrypt failure, or policy denial).
+    pub fn sign(&mut self, encrypted_request_payload: &[u8]) -> Result<Option<String>> {
+        let (ty, resp) = self.transact(
+            FRAME_TYPE_ENCRYPTED_REQUEST,
+            encrypted_request_payload,
+            SIGN_TIMEOUT,
+        )?;
+        match ty {
+            FRAME_TYPE_SIGN_ENVELOPE_RESPONSE => {
+                let json = String::from_utf8(resp).context("response event was not UTF-8")?;
+                Ok(Some(json))
+            }
+            FRAME_TYPE_NACK => Ok(None),
+            other => bail!("unexpected response to ENCRYPTED_REQUEST: {other:#04x}"),
+        }
+    }
+}

--- a/crates/heartwood-device/src/web.rs
+++ b/crates/heartwood-device/src/web.rs
@@ -1809,7 +1809,10 @@ fn build_frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
     let len = payload.len() as u16;
     frame.extend_from_slice(&len.to_be_bytes());
     frame.extend_from_slice(payload);
-    let checksum = crc32fast::hash(&frame);
+    // CRC covers type + length + payload, NOT the 2 magic bytes — matching the
+    // firmware (heartwood-esp32 common/src/frame.rs). Hashing the whole frame
+    // (including magic) here would be rejected by the device.
+    let checksum = crc32fast::hash(&frame[FRAME_MAGIC.len()..]);
     frame.extend_from_slice(&checksum.to_be_bytes());
     frame
 }
@@ -1860,7 +1863,8 @@ fn read_frame(
         // Verify CRC over everything except the trailing 4-byte CRC itself
         let expected_crc =
             u32::from_be_bytes([buf[total - 4], buf[total - 3], buf[total - 2], buf[total - 1]]);
-        let actual_crc = crc32fast::hash(&buf[..total - 4]);
+        // CRC covers type + length + payload, NOT the 2 magic bytes.
+        let actual_crc = crc32fast::hash(&buf[FRAME_MAGIC.len()..total - 4]);
         if actual_crc != expected_crc {
             return Err("CRC mismatch in ESP32 response".to_string());
         }

--- a/docs/2026-06-25-relay-serial-bridge.md
+++ b/docs/2026-06-25-relay-serial-bridge.md
@@ -1,0 +1,155 @@
+# Relay-to-serial signing bridge (`heartwood-bridge`)
+
+**Status:** Implemented (crate builds, unit-tested); not yet exercised against hardware.
+**Date:** 2026-06-25
+**Crate:** `crates/heartwood-bridge`
+
+## What this fills
+
+The architecture has long listed an **HSM operational mode** — *"no master secret on the
+Pi; NIP-46 requests are forwarded to an ESP32 hardware security module over a serial
+port."* In practice only the **management** half existed (`/api/hsm/pin`, `/api/hsm/detect`
+in `heartwood-device`): the Pi could set a PIN or detect a device, but **nothing carried
+signing traffic between the relays and the device.** The relay-facing component, the Node
+`bunker/` sidecar, is a *software* signer (`finalizeEvent(template, sk)`); it holds an nsec
+and has no serial path. So HSM mode could be configured but could not actually sign.
+
+`heartwood-bridge` is the missing data plane: a sidecar daemon that connects the Nostr
+relays to a USB-tethered signing device. It is the device's network. This is what lets a
+**Wi-Fi-less signer (e.g. an ESP8266, or an ESP32 with its radio deliberately off)**
+participate in the relay-mediated ecosystem — the daemon listens to relays on its behalf
+and pumps requests over USB.
+
+## Why the bridge is *thin*
+
+The firmware does all the cryptography **inline on the device**
+(`heartwood-esp32 firmware/src/transport.rs::handle_encrypted_request`). On one
+`ENCRYPTED_REQUEST` frame the device:
+
+1. NIP-44-decrypts the request (master secret × client pubkey conversation key),
+2. handles the NIP-46 method (sign_event, get_public_key, nip44_*, derive, …),
+3. re-encrypts the response,
+4. builds **and signs** the kind:24133 response envelope,
+5. returns a fully-serialised signed event, *"ready to publish to relays verbatim."*
+
+It is built this way on purpose — an earlier multi-round-trip design (send the response
+back to the device just to sign the envelope) sent ~7 KB over serial and *"caused silent
+ESP32 reboots."*
+
+So the bridge **never holds key material and never sees plaintext.** It is a pump:
+
+```
+relay  ──kind:24133 request──►  bridge  ──0x10 ENCRYPTED_REQUEST──►  device
+relay  ◄──signed response─────  bridge  ◄──0x35 SIGN_ENVELOPE_RESP─  device
+```
+
+## The serial contract
+
+All frames are `[magic "HW"][type u8][len u16-be][payload][crc32-be]`. **The CRC covers
+`type + len + payload`, NOT the magic** (see the bug note below). Frame types are a subset
+of `heartwood-esp32 common/src/types.rs`.
+
+| Step | Host → device | Device → host |
+|------|---------------|----------------|
+| Authenticate the bridge session | `SESSION_AUTH (0x21)` + 32-byte secret | `SESSION_ACK (0x22)` `[0x00]` ok / `[0x01]` wrong / `[0x02]` none |
+| Discover masters | `PROVISION_LIST (0x05)` | `0x07` JSON `[{slot,label,mode,npub}]` |
+| (Optional) sanity check | `FIRMWARE_INFO (0x59)` | `0x5A` `{version,board}` |
+| Sign a request | `ENCRYPTED_REQUEST (0x10)` payload below | `SIGN_ENVELOPE_RESPONSE (0x35)` signed event JSON, or `NACK (0x15)` |
+
+`0x10` payload: `[master_pk 32][client_pk 32][created_at u64-be 8][ciphertext bytes…]`
+
+- `master_pk` — the request event's `p` tag (one of our masters); the device only uses it
+  as a lookup key, never trusting it for the event's author field.
+- `client_pk` — the request event author.
+- `created_at` — **the bridge supplies the current unix time**, which the device writes
+  into the response envelope. The device has no reliable clock; that is *why* the host
+  passes it.
+- `ciphertext` — the request event's `content` (a NIP-44 base64 string) forwarded verbatim.
+
+`ENCRYPTED_REQUEST` is gated on a successful `SESSION_AUTH`. `SIGN_ENVELOPE (0x34)` is
+**deprecated** in the firmware ("envelope signing is now inline") and is not used.
+
+## Process shape
+
+```
+                       ┌───────────── tokio async ─────────────┐
+ relay A ⇄ ws ─┐       │  relay task A ─┐                       │
+ relay B ⇄ ws ─┼───────┼─ relay task B ─┼─ mpsc(jobs) ─►        │
+ relay C ⇄ ws ─┘       │  relay task C ─┘             ┌─────────▼──────────┐ blocking thread
+                       │      ▲                       │   serial worker    │ owns the port
+                       │      └── broadcast(signed) ──┤  0x10 → 0x35 (seq)  │ ⇄ USB ⇄ device
+                       └───────────────────────────── └────────────────────┘
+```
+
+- **One serial worker thread** owns the port (serial I/O is blocking). It authenticates,
+  discovers masters (reported back via a `oneshot` so the relay tasks can build filters),
+  then processes jobs **strictly sequentially** — the device answers one request at a time,
+  and a sign may block up to ~45 s on a physical button press (TOFU "ask" policy). On any
+  serial error it reopens and re-authenticates with backoff, retrying forever.
+- **One async task per relay** subscribes `["REQ", …, {kinds:[24133], "#p":[masters], since:now}]`,
+  forwards **de-duplicated** request events (the same request arrives from several relays;
+  a bounded seen-set ensures we sign once), and publishes every signed response to **all**
+  relays. Reconnects with capped backoff.
+- Relay client is raw `tokio-tungstenite` + `serde_json` (no `nostr-sdk`), so the device's
+  signed event is republished **byte-for-byte** and the dependency surface stays small.
+
+## Configuration
+
+Read from the shared instance dir (`HEARTWOOD_DATA_DIR`, default `/var/lib/heartwood/<i>`):
+
+| Source | Field | Use |
+|--------|-------|-----|
+| `master.payload` | `hsm:<serial_port>` | the device's serial port (HSM mode marker; no key) |
+| `config.json` | `relays` | relay list (falls back to the Pi defaults) |
+| `bridge.secret` | 64-hex or 32 raw bytes | the serial bridge-session secret, shared with the device's NVS |
+
+## Security model
+
+- **No key, no plaintext on the host.** The bridge forwards ciphertext and republishes a
+  signed event. Confidentiality and authority live on the device.
+- **`bridge.secret`** authenticates the serial session (constant-time compared in firmware;
+  setting it on the device needs a physical button hold). It is *not* the signing key — it
+  authorises the USB pump, nothing more. Treat the file as a local secret (mode 0600).
+- **Replay / policy** are the device's job: it enforces NIP-44 integrity, kind allowlists,
+  rate limits and per-client TOFU policy, and NACKs anything it dislikes. The bridge only
+  de-duplicates request ids to avoid double-submitting the same event.
+- **What a relay sees:** the same metadata NIP-46 already exposes (a master pubkey is
+  online, request/response timing). No new secret leakage.
+- **NIP-42 AUTH is unsupported.** The bridge holds no key, so it cannot sign an auth
+  challenge. Relays that require AUTH for kind-24133 are out of scope; use open relays for
+  the tethered tier (or the device-direct Wi-Fi-standalone tier where the device signs its
+  own AUTH).
+
+## Deployment
+
+`boards/pi/heartwood-bridge@.service` — a sidecar template unit mirroring
+`heartwood-bunker@.service`, plus serial access (`SupplementaryGroups=dialout`,
+`DeviceAllow=char-ttyUSB/ttyACM rw`). It is the HSM-mode counterpart of the bunker: in
+non-HSM modes the Node bunker signs; in HSM mode the bridge pumps to the device. They are
+mutually exclusive by mode.
+
+## Fixed — `heartwood-device` web serial CRC
+
+While matching the firmware's wire format I found that `heartwood-device/src/web.rs`'s
+private `build_frame`/`read_frame` computed the CRC over **`crc32fast::hash(&frame)`** —
+i.e. **including the magic bytes** — whereas the firmware
+(`heartwood-esp32 common/src/frame.rs`) hashes **`type + len + payload` only**. They
+disagreed, so the existing `/api/hsm/pin` (`SET_PIN`) path was **wire-incompatible with the
+device** and would fail CRC. It had likely never been exercised against hardware (HSM
+signing did not exist until now). **Fixed** in this change (both sites now hash from
+`FRAME_MAGIC.len()`, matching the firmware). The proper long-term fix is to share one
+codec (a future `heartwood-frame` crate) so `web.rs` and the bridge cannot drift again.
+
+## Status & follow-ups
+
+- ✅ Crate builds; 19 unit tests pass (frame round-trip + firmware-parity CRC, npub decode
+  vs the NIP-19 vector, request parsing, `0x10` payload layout, dedup, secret parsing).
+- ⏳ **Hardware bring-up** — run against a provisioned ESP32 (set a `bridge.secret`, plug
+  in, sign from a NIP-46 client). Not yet done.
+- ⏳ **Provisioning UX** — where the operator sets `bridge.secret` on *both* the device
+  (`SET_BRIDGE_SECRET 0x23`, with button) and the Pi (`bridge.secret` file). Today it must
+  be placed by hand; Sapwood/the web setup should write both.
+- ✅ **`web.rs` CRC fixed** (above); the shared-frame-crate refactor remains a follow-up.
+- ⏳ **ESP8266 firmware** — the device half for a truly Wi-Fi-less signer. The spike proved
+  the crypto fits; a `no_std` UART + frame + inline-sign firmware is a separate build, and
+  the inline NIP-44 + JSON path needs an on-8266 RAM check.

--- a/docs/2026-06-25-relay-serial-bridge.md
+++ b/docs/2026-06-25-relay-serial-bridge.md
@@ -142,8 +142,12 @@ codec (a future `heartwood-frame` crate) so `web.rs` and the bridge cannot drift
 
 ## Status & follow-ups
 
-- ✅ Crate builds; 19 unit tests pass (frame round-trip + firmware-parity CRC, npub decode
-  vs the NIP-19 vector, request parsing, `0x10` payload layout, dedup, secret parsing).
+- ✅ Crate builds; 20 tests pass — 19 unit (frame round-trip + firmware-parity CRC, npub
+  decode vs the NIP-19 vector, request parsing, `0x10` payload layout, dedup, secret
+  parsing) plus a hardware-free **end-to-end** test driving the real relay client and the
+  real `SerialSession` over a socket pair + a local websocket relay against a device
+  simulator (relay → `0x10` → simulated device → `0x35` → relay), verified stable over
+  repeated runs.
 - ⏳ **Hardware bring-up** — run against a provisioned ESP32 (set a `bridge.secret`, plug
   in, sign from a NIP-46 client). Not yet done.
 - ⏳ **Provisioning UX** — where the operator sets `bridge.secret` on *both* the device


### PR DESCRIPTION
## Summary

Adds `heartwood-bridge`, the missing **data plane for HSM mode**: a sidecar daemon that connects the Nostr relays to a USB-tethered signing device. Until now HSM mode could be configured (PIN / detect) but nothing carried signing traffic — the relay-facing bunker is a software signer with no serial path. This is what lets a Wi-Fi-less signer (ESP8266, or an ESP32 with its radio off) participate in the ecosystem via the daemon.

Because the firmware does **all cryptography inline** on a single `ENCRYPTED_REQUEST (0x10)` frame (NIP-44 decrypt → handle the NIP-46 method → re-encrypt → sign the kind:24133 envelope → return a fully-signed event), the bridge is a **thin pump that never holds key material or sees plaintext**:

1. authenticate the serial session (`SESSION_AUTH 0x21`),
2. discover the master pubkey (`PROVISION_LIST 0x05`),
3. subscribe relays for kind `24133` `#p=master`,
4. pump each request `0x10` → `0x35`,
5. publish the device's signed event **verbatim**.

## Changes

- **`crates/heartwood-bridge`** (new) — serial session, relay client over raw `tokio-tungstenite` (no `nostr-sdk`, so the device's signature republishes byte-for-byte), a blocking serial-worker thread + one async task per relay, cross-relay de-duplication, graceful shutdown.
- **fix** — `heartwood-device/web.rs` computed its serial CRC over the whole frame *including* the magic bytes, but the firmware hashes `type + len + payload` only. The existing `/api/hsm/pin` (`SET_PIN`) path was therefore wire-incompatible with the device; fixed to match the firmware (authoritative).
- **`boards/pi/heartwood-bridge@.service`** — systemd sidecar unit (mirrors the bunker, plus serial device access).
- **`docs/2026-06-25-relay-serial-bridge.md`** — design note + threat model.
- **`ARCHITECTURE.md`** — three runtime components; HSM mode now has a data plane.

## Testing

20 tests pass, clippy clean:

- 19 unit — frame round-trip + a **firmware-parity CRC** test, npub decode vs the NIP-19 vector, request parsing, `0x10` payload layout, dedup, secret parsing.
- 1 **hardware-free end-to-end** — a kind:24133 request injected at a real local websocket relay flows through the real relay client and the real `SerialSession` (over a `UnixStream` pair) to a device simulator and back, published verbatim. Stable over 12/12 repeated runs.

## Not covered (follow-ups, in the design note)

- Hardware bring-up against a provisioned ESP32 (+ a `bridge.secret`).
- Provisioning UX for `bridge.secret` (set on device via `SET_BRIDGE_SECRET 0x23` + write the Pi-side file).
- The ESP8266 **device** firmware (the spike proved the crypto fits; a `no_std` UART + frame + inline-sign firmware is a separate build).
