### PR TITLE
Serial frame coverage + fix the device read_frame payload offset

### DIFF
--- a/crates/heartwood-bridge/src/frame.rs
+++ b/crates/heartwood-bridge/src/frame.rs
@@ -187,4 +187,86 @@ mod tests {
         hasher.update(payload);
         assert_eq!(emitted, hasher.finalize(), "CRC must exclude the magic bytes");
     }
+
+    // --- read_frame: streaming, resynchronisation and timeout ------------
+
+    /// A `Read` that yields a scripted byte stream one byte per call, with
+    /// optional `WouldBlock`/`TimedOut` stalls interleaved, then reports
+    /// `TimedOut` forever once drained — modelling a real serial port that
+    /// dribbles bytes slowly and returns read timeouts in between.
+    struct DribbleReader {
+        script: std::collections::VecDeque<std::io::Result<u8>>,
+    }
+
+    impl DribbleReader {
+        fn bytes(data: impl AsRef<[u8]>) -> Self {
+            Self { script: data.as_ref().iter().map(|&b| Ok(b)).collect() }
+        }
+        fn stall(&mut self, kind: std::io::ErrorKind) {
+            self.script.push_back(Err(std::io::Error::new(kind, "stall")));
+        }
+        fn then(&mut self, data: &[u8]) {
+            self.script.extend(data.iter().map(|&b| Ok(b)));
+        }
+    }
+
+    impl std::io::Read for DribbleReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            match self.script.pop_front() {
+                Some(Ok(b)) => {
+                    buf[0] = b;
+                    Ok(1)
+                }
+                Some(Err(e)) => Err(e),
+                None => Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "drained")),
+            }
+        }
+    }
+
+    #[test]
+    fn read_frame_reassembles_from_single_byte_reads() {
+        let frame = build_frame(FRAME_TYPE_SIGN_ENVELOPE_RESPONSE, b"streamed");
+        let mut reader = DribbleReader::bytes(&frame);
+        let (ty, payload) = read_frame(&mut reader, Duration::from_secs(1)).unwrap();
+        assert_eq!(ty, FRAME_TYPE_SIGN_ENVELOPE_RESPONSE);
+        assert_eq!(payload, b"streamed");
+    }
+
+    #[test]
+    fn read_frame_skips_leading_boot_banner() {
+        // Junk before the frame (e.g. a firmware boot banner) must be skipped by
+        // resynchronising on the magic preamble, not treated as a fatal error.
+        let mut bytes = b"esp32 boot\r\nready\r\n".to_vec();
+        assert!(
+            !bytes.windows(2).any(|w| w[0] == FRAME_MAGIC[0] && w[1] == FRAME_MAGIC[1]),
+            "fixture must not accidentally contain the magic"
+        );
+        bytes.extend_from_slice(&build_frame(FRAME_TYPE_NACK, b"x"));
+        let mut reader = DribbleReader::bytes(&bytes);
+        let (ty, payload) = read_frame(&mut reader, Duration::from_secs(1)).unwrap();
+        assert_eq!(ty, FRAME_TYPE_NACK);
+        assert_eq!(payload, b"x");
+    }
+
+    #[test]
+    fn read_frame_keeps_waiting_through_stalls() {
+        let frame = build_frame(FRAME_TYPE_PROVISION_LIST_RESPONSE, b"payload");
+        let mut reader = DribbleReader::bytes(&frame[..3]); // a few bytes...
+        reader.stall(std::io::ErrorKind::WouldBlock); // ...then a non-fatal stall...
+        reader.stall(std::io::ErrorKind::TimedOut); // ...and another...
+        reader.then(&frame[3..]); // ...then the rest of the frame.
+        let (ty, payload) = read_frame(&mut reader, Duration::from_secs(1)).unwrap();
+        assert_eq!(ty, FRAME_TYPE_PROVISION_LIST_RESPONSE);
+        assert_eq!(payload, b"payload");
+    }
+
+    #[test]
+    fn read_frame_times_out_when_silent() {
+        let mut reader = DribbleReader::bytes(b""); // immediately drained → TimedOut
+        let err = read_frame(&mut reader, Duration::from_millis(80)).unwrap_err().to_string();
+        assert!(err.contains("timed out"), "{err}");
+    }
 }

--- a/crates/heartwood-bridge/src/serial.rs
+++ b/crates/heartwood-bridge/src/serial.rs
@@ -146,3 +146,269 @@ impl SerialSession {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::{
+        build_frame, parse_complete, FRAME_OVERHEAD, FRAME_TYPE_ENCRYPTED_REQUEST,
+        FRAME_TYPE_FIRMWARE_INFO_RESPONSE, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
+        FRAME_TYPE_PROVISION_LIST_RESPONSE, FRAME_TYPE_SESSION_ACK, FRAME_TYPE_SESSION_AUTH,
+        FRAME_TYPE_SIGN_ENVELOPE_RESPONSE,
+    };
+    use serde_json::json;
+    use std::collections::VecDeque;
+
+    // NIP-19 vector: this npub decodes to MASTER_HEX (shared with the e2e test).
+    const MASTER_NPUB: &str = "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6";
+    const MASTER_HEX: &str = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d";
+    const SECRET: [u8; 32] = [0x42; 32];
+
+    /// A fully in-process mock device. Each complete frame the session writes is
+    /// handed to `handler`, whose optional `(type, payload)` reply is queued for
+    /// the session to read straight back. There are no sockets or threads:
+    /// `write_all` runs the handler synchronously, so the reply is already
+    /// buffered by the time the session reads it. This drives the *real* frame
+    /// codec in both directions, so every `SerialSession` branch is exercised
+    /// against genuinely-encoded frames.
+    /// `(frame_type, payload) -> optional (reply_type, reply_payload)`.
+    type FrameHandler = Box<dyn FnMut(u8, Vec<u8>) -> Option<(u8, Vec<u8>)> + Send>;
+
+    struct MockDevice {
+        handler: FrameHandler,
+        inbound: Vec<u8>,       // host → device bytes, until a whole frame lands
+        outbound: VecDeque<u8>, // device → host reply bytes awaiting a read
+    }
+
+    impl MockDevice {
+        fn new<H>(handler: H) -> Self
+        where
+            H: FnMut(u8, Vec<u8>) -> Option<(u8, Vec<u8>)> + Send + 'static,
+        {
+            Self { handler: Box::new(handler), inbound: Vec::new(), outbound: VecDeque::new() }
+        }
+
+        /// Pull one complete frame off `inbound` (if present), run the handler,
+        /// and queue its reply. Returns whether a frame was consumed.
+        fn consume_one_frame(&mut self) -> bool {
+            if self.inbound.len() < FRAME_OVERHEAD {
+                return false;
+            }
+            let payload_len = u16::from_be_bytes([self.inbound[3], self.inbound[4]]) as usize;
+            let total = FRAME_OVERHEAD + payload_len;
+            if self.inbound.len() < total {
+                return false;
+            }
+            let (ty, payload) =
+                parse_complete(&self.inbound[..total]).expect("session emitted a malformed frame");
+            self.inbound.drain(..total);
+            if let Some((reply_ty, reply_payload)) = (self.handler)(ty, payload) {
+                self.outbound.extend(build_frame(reply_ty, &reply_payload));
+            }
+            true
+        }
+    }
+
+    impl std::io::Read for MockDevice {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            match self.outbound.pop_front() {
+                Some(b) => {
+                    buf[0] = b;
+                    Ok(1)
+                }
+                // No reply queued: model a serial read timeout so `read_frame`
+                // keeps waiting rather than treating it as EOF.
+                None => Err(std::io::Error::new(std::io::ErrorKind::WouldBlock, "no reply queued")),
+            }
+        }
+    }
+
+    impl std::io::Write for MockDevice {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.inbound.extend_from_slice(buf);
+            while self.consume_one_frame() {}
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A session wired to a scripted mock device.
+    fn session_with<H>(handler: H) -> SerialSession
+    where
+        H: FnMut(u8, Vec<u8>) -> Option<(u8, Vec<u8>)> + Send + 'static,
+    {
+        SerialSession::from_io(Box::new(MockDevice::new(handler)))
+    }
+
+    /// A session whose device always replies with the same frame.
+    fn always_replies(reply_ty: u8, payload: Vec<u8>) -> SerialSession {
+        session_with(move |_, _| Some((reply_ty, payload.clone())))
+    }
+
+    // --- authenticate (0x21 → 0x22) --------------------------------------
+
+    #[test]
+    fn authenticate_accepts_status_zero() {
+        let mut session = session_with(|ty, payload| {
+            assert_eq!(ty, FRAME_TYPE_SESSION_AUTH, "sends SESSION_AUTH");
+            assert_eq!(payload.as_slice(), &SECRET[..], "presents the secret verbatim");
+            Some((FRAME_TYPE_SESSION_ACK, vec![0x00]))
+        });
+        session.authenticate(&SECRET).expect("status 0x00 is success");
+    }
+
+    #[test]
+    fn authenticate_wrong_secret_is_a_named_error() {
+        let mut session = always_replies(FRAME_TYPE_SESSION_ACK, vec![0x01]);
+        let err = session.authenticate(&SECRET).unwrap_err().to_string();
+        assert!(err.contains("wrong secret"), "{err}");
+    }
+
+    #[test]
+    fn authenticate_unprovisioned_is_a_named_error() {
+        let mut session = always_replies(FRAME_TYPE_SESSION_ACK, vec![0x02]);
+        let err = session.authenticate(&SECRET).unwrap_err().to_string();
+        assert!(err.contains("no bridge secret"), "{err}");
+    }
+
+    #[test]
+    fn authenticate_unknown_status_is_rejected() {
+        let mut session = always_replies(FRAME_TYPE_SESSION_ACK, vec![0x7f]);
+        assert!(session.authenticate(&SECRET).is_err());
+    }
+
+    #[test]
+    fn authenticate_empty_ack_payload_is_rejected() {
+        // status.first() == None must not be read as success.
+        let mut session = always_replies(FRAME_TYPE_SESSION_ACK, vec![]);
+        assert!(session.authenticate(&SECRET).is_err());
+    }
+
+    #[test]
+    fn authenticate_wrong_frame_type_is_rejected() {
+        let mut session = always_replies(FRAME_TYPE_NACK, vec![]);
+        let err = session.authenticate(&SECRET).unwrap_err().to_string();
+        assert!(err.contains("SESSION_ACK"), "{err}");
+    }
+
+    // --- list_master_pubkeys (0x05 → 0x07) -------------------------------
+
+    #[test]
+    fn list_decodes_npub_to_hex() {
+        let infos = json!([{ "slot": 0, "label": "test", "mode": 1, "npub": MASTER_NPUB }]);
+        let mut session =
+            always_replies(FRAME_TYPE_PROVISION_LIST_RESPONSE, infos.to_string().into_bytes());
+        assert_eq!(session.list_master_pubkeys().unwrap(), vec![MASTER_HEX.to_string()]);
+    }
+
+    #[test]
+    fn list_skips_undecodable_npub_but_keeps_the_good_one() {
+        let infos = json!([
+            { "npub": "npub1thisisnotvalidbech32" },
+            { "npub": MASTER_NPUB },
+        ]);
+        let mut session =
+            always_replies(FRAME_TYPE_PROVISION_LIST_RESPONSE, infos.to_string().into_bytes());
+        assert_eq!(session.list_master_pubkeys().unwrap(), vec![MASTER_HEX.to_string()]);
+    }
+
+    #[test]
+    fn list_empty_is_an_error() {
+        let mut session = always_replies(FRAME_TYPE_PROVISION_LIST_RESPONSE, b"[]".to_vec());
+        let err = session.list_master_pubkeys().unwrap_err().to_string();
+        assert!(err.contains("no provisioned masters"), "{err}");
+    }
+
+    #[test]
+    fn list_invalid_json_is_an_error() {
+        let mut session = always_replies(FRAME_TYPE_PROVISION_LIST_RESPONSE, b"not json".to_vec());
+        assert!(session.list_master_pubkeys().is_err());
+    }
+
+    #[test]
+    fn list_wrong_frame_type_is_rejected() {
+        let mut session = always_replies(FRAME_TYPE_NACK, vec![]);
+        let err = session.list_master_pubkeys().unwrap_err().to_string();
+        assert!(err.contains("PROVISION_LIST_RESPONSE"), "{err}");
+    }
+
+    // --- sign (0x10 → 0x35 | 0x15) ---------------------------------------
+
+    #[test]
+    fn sign_returns_event_json_on_envelope_response() {
+        let event = r#"{"id":"cc","kind":24133,"sig":"dd"}"#;
+        let mut session = session_with(move |ty, _| {
+            assert_eq!(ty, FRAME_TYPE_ENCRYPTED_REQUEST, "sends ENCRYPTED_REQUEST");
+            Some((FRAME_TYPE_SIGN_ENVELOPE_RESPONSE, event.as_bytes().to_vec()))
+        });
+        assert_eq!(session.sign(b"payload").unwrap().as_deref(), Some(event));
+    }
+
+    #[test]
+    fn sign_returns_none_on_nack() {
+        // A device NACK (unknown master / decrypt failure / policy denial) is a
+        // clean "no result", not an error — the worker just logs and moves on.
+        let mut session = always_replies(FRAME_TYPE_NACK, vec![]);
+        assert_eq!(session.sign(b"payload").unwrap(), None);
+    }
+
+    #[test]
+    fn sign_unexpected_frame_type_is_an_error() {
+        let mut session = always_replies(FRAME_TYPE_SESSION_ACK, vec![0x00]);
+        let err = session.sign(b"payload").unwrap_err().to_string();
+        assert!(err.contains("unexpected response"), "{err}");
+    }
+
+    #[test]
+    fn sign_non_utf8_response_is_an_error() {
+        let mut session = always_replies(FRAME_TYPE_SIGN_ENVELOPE_RESPONSE, vec![0xff, 0xfe]);
+        assert!(session.sign(b"payload").is_err());
+    }
+
+    // --- firmware_info (0x59 → 0x5A) -------------------------------------
+
+    #[test]
+    fn firmware_info_parses_json() {
+        let info = json!({ "version": "0.9.7", "board": "esp8266" });
+        let mut session =
+            always_replies(FRAME_TYPE_FIRMWARE_INFO_RESPONSE, info.to_string().into_bytes());
+        let got = session.firmware_info().unwrap();
+        assert_eq!(got["version"], "0.9.7");
+    }
+
+    #[test]
+    fn firmware_info_wrong_frame_type_is_rejected() {
+        let mut session = always_replies(FRAME_TYPE_NACK, vec![]);
+        assert!(session.firmware_info().is_err());
+    }
+
+    // --- whole-session reuse ---------------------------------------------
+
+    #[test]
+    fn one_session_handles_auth_list_then_repeated_signs() {
+        // The e2e exercises a single sign. This proves the codec re-synchronises
+        // across many transactions on one long-lived session, as the real
+        // serial worker drives it.
+        let mut session = session_with(|ty, _| match ty {
+            FRAME_TYPE_SESSION_AUTH => Some((FRAME_TYPE_SESSION_ACK, vec![0x00])),
+            FRAME_TYPE_PROVISION_LIST => Some((
+                FRAME_TYPE_PROVISION_LIST_RESPONSE,
+                json!([{ "npub": MASTER_NPUB }]).to_string().into_bytes(),
+            )),
+            FRAME_TYPE_ENCRYPTED_REQUEST => {
+                Some((FRAME_TYPE_SIGN_ENVELOPE_RESPONSE, b"{\"ok\":true}".to_vec()))
+            }
+            _ => Some((FRAME_TYPE_NACK, vec![])),
+        });
+        session.authenticate(&SECRET).unwrap();
+        assert_eq!(session.list_master_pubkeys().unwrap(), vec![MASTER_HEX.to_string()]);
+        for _ in 0..3 {
+            assert_eq!(session.sign(b"req").unwrap().as_deref(), Some("{\"ok\":true}"));
+        }
+    }
+}

--- a/crates/heartwood-device/src/web.rs
+++ b/crates/heartwood-device/src/web.rs
@@ -1820,8 +1820,8 @@ fn build_frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
 /// Read one complete frame from the serial port (blocking, up to `timeout`).
 ///
 /// Returns `(frame_type, payload)` or an error string.
-fn read_frame(
-    port: &mut dyn serialport::SerialPort,
+fn read_frame<R: std::io::Read + ?Sized>(
+    port: &mut R,
     timeout: std::time::Duration,
 ) -> Result<(u8, Vec<u8>), String> {
     let deadline = std::time::Instant::now() + timeout;
@@ -1869,7 +1869,8 @@ fn read_frame(
             return Err("CRC mismatch in ESP32 response".to_string());
         }
 
-        let payload = buf[7..total - 4].to_vec();
+        // Payload starts after the 5-byte header (magic 2 + type 1 + len 2).
+        let payload = buf[5..total - 4].to_vec();
         return Ok((frame_type, payload));
     }
 }
@@ -2273,5 +2274,70 @@ mod tests {
         assert!(!is_valid_pair_name("has spaces"));
         assert!(!is_valid_pair_name("has/slash"));
         assert!(!is_valid_pair_name(&"a".repeat(65)));
+    }
+
+    // --- serial frame codec (the /api/hsm/pin transport) -----------------
+
+    #[test]
+    fn read_frame_returns_empty_payload_ack_without_panicking() {
+        // Regression: the firmware ACKs SET_PIN with an EMPTY payload (a 9-byte
+        // frame). The old `buf[7..total - 4]` slice became `buf[7..5]` — a
+        // reversed range that panicked on every successful PIN operation. The
+        // correct header is 5 bytes, so the payload slice must start at 5.
+        let frame = build_frame(FRAME_TYPE_ACK, &[]);
+        let mut reader = frame.as_slice();
+        let (ty, payload) =
+            read_frame(&mut reader, std::time::Duration::from_secs(1)).expect("must not panic");
+        assert_eq!(ty, FRAME_TYPE_ACK);
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn read_frame_recovers_the_full_payload() {
+        // The old offset silently dropped the first two payload bytes; assert
+        // every byte survives the round trip.
+        let payload = b"npub1exampledata";
+        let frame = build_frame(0x07, payload);
+        let mut reader = frame.as_slice();
+        let (ty, got) =
+            read_frame(&mut reader, std::time::Duration::from_secs(1)).expect("reads a frame");
+        assert_eq!(ty, 0x07);
+        assert_eq!(got, payload);
+    }
+
+    #[test]
+    fn read_frame_skips_boot_banner_noise() {
+        let mut bytes = b"esp32 ready\r\n".to_vec();
+        assert!(!bytes.windows(2).any(|w| w[0] == FRAME_MAGIC[0] && w[1] == FRAME_MAGIC[1]));
+        bytes.extend_from_slice(&build_frame(FRAME_TYPE_NACK, &[]));
+        let mut reader = bytes.as_slice();
+        let (ty, payload) =
+            read_frame(&mut reader, std::time::Duration::from_secs(1)).expect("reads a frame");
+        assert_eq!(ty, FRAME_TYPE_NACK);
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn read_frame_rejects_crc_corruption() {
+        let mut frame = build_frame(FRAME_TYPE_SET_PIN, b"1234");
+        let last = frame.len() - 1;
+        frame[last] ^= 0xff; // corrupt the trailing CRC
+        let mut reader = frame.as_slice();
+        assert!(read_frame(&mut reader, std::time::Duration::from_secs(1)).is_err());
+    }
+
+    #[test]
+    fn build_frame_crc_excludes_the_magic() {
+        // This is a second copy of the bridge's frame codec; pin the CRC scheme
+        // so the two cannot drift (a mismatch silently breaks the wire format
+        // against real firmware — the exact bug fixed when the bridge landed).
+        let payload = b"abc";
+        let frame = build_frame(FRAME_TYPE_SET_PIN, payload);
+        let crc = u32::from_be_bytes([frame[8], frame[9], frame[10], frame[11]]);
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&[FRAME_TYPE_SET_PIN]);
+        hasher.update(&(payload.len() as u16).to_be_bytes());
+        hasher.update(payload);
+        assert_eq!(crc, hasher.finalize(), "CRC must exclude the 2 magic bytes");
     }
 }


### PR DESCRIPTION
## Summary

Closes the failure-branch coverage gap on the relay-to-serial signing path, and fixes a real bug the new tests surfaced.

### `heartwood-bridge` — test coverage (no behaviour change)

The pump had one happy-path e2e test and zero direct coverage of the `SerialSession` failure branches the production code handles.

- **`serial.rs`** — an in-process `MockDevice` (scriptable, synchronous; `write_all` runs the handler so the reply is buffered before the session reads) drives every branch through the *real* frame codec: auth `0x00`/`0x01`/`0x02`/unknown/empty/wrong-frame; sign envelope / NACK→`None` / unexpected / non-UTF8; provision-list decode / skip-undecodable / empty / bad-JSON / wrong-frame; firmware-info parse / wrong-frame; and a long-lived auth→list→repeated-sign session.
- **`frame.rs`** — a portable `DribbleReader` exercises `read_frame`'s byte-at-a-time reassembly, leading boot-banner resync, `WouldBlock`/`TimedOut` stalls, and the silent timeout.

### `heartwood-device` — bug fix

`web.rs` carries a second copy of the codec for the `/api/hsm/pin` path. Its `read_frame` returned `buf[7..total - 4]`, but the header is **5 bytes** (magic 2 + type 1 + len 2) and the file's own `build_frame` writes the payload at offset 5. The bridge's authoritative codec uses `buf[5..]`.

- The firmware ACKs `SET_PIN` with an **empty** payload (a 9-byte frame) → `buf[7..5]` is a reversed range → **panic → HTTP 500 on every PIN set/clear**.
- For payloads ≥ 2 bytes it silently dropped the first two bytes.

Latent only because the path is not yet exercised against hardware. Fixed the offset to `5`, made `read_frame` generic over `Read` for testability, and added regression tests **confirmed to panic / mismatch against the old offset before the fix**:

```
read_frame_returns_empty_payload_ack…  → "slice index starts at 7 but ends at 5"
read_frame_recovers_the_full_payload   → left "ub1…" vs right "npub1…"
```

## Test

`cargo fmt` clean · `cargo clippy` clean · **42 bridge + 36 device tests pass** (+27 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
