### PR TITLE
refactor: extract the serial frame codec into a shared heartwood-frame crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,8 +614,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bech32",
- "crc32fast",
  "futures-util",
+ "heartwood-frame",
  "serde",
  "serde_json",
  "serialport",
@@ -634,7 +634,7 @@ dependencies = [
  "axum",
  "base64",
  "bip39",
- "crc32fast",
+ "heartwood-frame",
  "nip46-signer",
  "nsec-tree-rs",
  "password-hash",
@@ -648,6 +648,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zeroize",
+]
+
+[[package]]
+name = "heartwood-frame"
+version = "0.1.0"
+dependencies = [
+ "crc32fast",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/heartwood-core",
     "crates/heartwood-nip46",
+    "crates/heartwood-frame",
     "crates/heartwood-device",
     "crates/heartwood-bridge",
 ]

--- a/crates/heartwood-bridge/Cargo.toml
+++ b/crates/heartwood-bridge/Cargo.toml
@@ -19,7 +19,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Blocking serial transport to the device (same crate the Pi web binary uses).
 serialport = "4"
-crc32fast = "1"
+# Shared binary serial frame codec (the same crate the Pi web binary uses).
+heartwood-frame = { path = "../heartwood-frame" }
 # npub (bech32) decoding for the master public key discovered over serial.
 bech32 = "0.11"
 anyhow = "1"

--- a/crates/heartwood-bridge/src/e2e.rs
+++ b/crates/heartwood-bridge/src/e2e.rs
@@ -18,13 +18,13 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_tungstenite::tungstenite::Message;
 
 use crate::dedup::Seen;
-use crate::frame::{
-    self, FRAME_TYPE_ENCRYPTED_REQUEST, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
+use crate::relay::{run_relay, RequestJob};
+use crate::serial::SerialSession;
+use heartwood_frame::{
+    self as frame, FRAME_TYPE_ENCRYPTED_REQUEST, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
     FRAME_TYPE_PROVISION_LIST_RESPONSE, FRAME_TYPE_SESSION_ACK, FRAME_TYPE_SESSION_AUTH,
     FRAME_TYPE_SIGN_ENVELOPE_RESPONSE,
 };
-use crate::relay::{run_relay, RequestJob};
-use crate::serial::SerialSession;
 
 // NIP-19 vector: this npub decodes to MASTER_HEX.
 const MASTER_NPUB: &str = "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6";

--- a/crates/heartwood-bridge/src/main.rs
+++ b/crates/heartwood-bridge/src/main.rs
@@ -14,7 +14,6 @@ mod bridge;
 mod config;
 mod dedup;
 mod event;
-mod frame;
 mod npub;
 mod relay;
 mod serial;

--- a/crates/heartwood-bridge/src/serial.rs
+++ b/crates/heartwood-bridge/src/serial.rs
@@ -10,13 +10,13 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
 
-use crate::frame::{
-    self, FRAME_TYPE_ENCRYPTED_REQUEST, FRAME_TYPE_FIRMWARE_INFO,
+use crate::npub;
+use heartwood_frame::{
+    self as frame, FRAME_TYPE_ENCRYPTED_REQUEST, FRAME_TYPE_FIRMWARE_INFO,
     FRAME_TYPE_FIRMWARE_INFO_RESPONSE, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
     FRAME_TYPE_PROVISION_LIST_RESPONSE, FRAME_TYPE_SESSION_ACK, FRAME_TYPE_SESSION_AUTH,
     FRAME_TYPE_SIGN_ENVELOPE_RESPONSE,
 };
-use crate::npub;
 
 const BAUD: u32 = 115_200;
 /// Per-`read` byte timeout used while assembling a frame.
@@ -79,7 +79,7 @@ impl SerialSession {
     ) -> Result<(u8, Vec<u8>)> {
         let frame = frame::build_frame(frame_type, payload);
         std::io::Write::write_all(&mut *self.io, &frame).context("serial write failed")?;
-        frame::read_frame(&mut *self.io, timeout)
+        Ok(frame::read_frame(&mut *self.io, timeout)?)
     }
 
     /// `SESSION_AUTH` (0x21): present the 32-byte shared secret and expect
@@ -150,7 +150,7 @@ impl SerialSession {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::frame::{
+    use heartwood_frame::{
         build_frame, parse_complete, FRAME_OVERHEAD, FRAME_TYPE_ENCRYPTED_REQUEST,
         FRAME_TYPE_FIRMWARE_INFO_RESPONSE, FRAME_TYPE_NACK, FRAME_TYPE_PROVISION_LIST,
         FRAME_TYPE_PROVISION_LIST_RESPONSE, FRAME_TYPE_SESSION_ACK, FRAME_TYPE_SESSION_AUTH,

--- a/crates/heartwood-device/Cargo.toml
+++ b/crates/heartwood-device/Cargo.toml
@@ -26,7 +26,7 @@ aes-gcm = "0.10"
 zeroize = "1"
 bip39 = "2"
 serialport = "4"
-crc32fast = "1"
+heartwood-frame = { path = "../heartwood-frame" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util", "macros"] }

--- a/crates/heartwood-device/src/web.rs
+++ b/crates/heartwood-device/src/web.rs
@@ -13,6 +13,9 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use heartwood_frame::{
+    build_frame, read_frame, FRAME_TYPE_ACK, FRAME_TYPE_NACK, FRAME_TYPE_SET_PIN,
+};
 use password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use rand_core::{OsRng, RngCore};
 use serde::Deserialize;
@@ -1795,85 +1798,10 @@ async fn api_list_slots(State(state): State<Arc<AppState>>) -> impl IntoResponse
     axum::Json(json!(slots))
 }
 
-/// Frame type bytes for the ESP32 serial protocol.
-const FRAME_MAGIC: [u8; 2] = [0x48, 0x57];
-const FRAME_TYPE_SET_PIN: u8 = 0x25;
-const FRAME_TYPE_ACK: u8 = 0x06;
-const FRAME_TYPE_NACK: u8 = 0x15;
-
-/// Build a framed serial message: `[magic_2][type_1][length_u16_be][payload…][crc32_4]`.
-fn build_frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
-    let mut frame = Vec::with_capacity(2 + 1 + 2 + payload.len() + 4);
-    frame.extend_from_slice(&FRAME_MAGIC);
-    frame.push(frame_type);
-    let len = payload.len() as u16;
-    frame.extend_from_slice(&len.to_be_bytes());
-    frame.extend_from_slice(payload);
-    // CRC covers type + length + payload, NOT the 2 magic bytes — matching the
-    // firmware (heartwood-esp32 common/src/frame.rs). Hashing the whole frame
-    // (including magic) here would be rejected by the device.
-    let checksum = crc32fast::hash(&frame[FRAME_MAGIC.len()..]);
-    frame.extend_from_slice(&checksum.to_be_bytes());
-    frame
-}
-
-/// Read one complete frame from the serial port (blocking, up to `timeout`).
-///
-/// Returns `(frame_type, payload)` or an error string.
-fn read_frame<R: std::io::Read + ?Sized>(
-    port: &mut R,
-    timeout: std::time::Duration,
-) -> Result<(u8, Vec<u8>), String> {
-    let deadline = std::time::Instant::now() + timeout;
-    let mut buf = Vec::with_capacity(64);
-
-    // Read bytes until we have a valid frame or time out.
-    loop {
-        if std::time::Instant::now() >= deadline {
-            return Err("timed out waiting for response from ESP32".to_string());
-        }
-
-        let mut byte = [0u8; 1];
-        match std::io::Read::read(port, &mut byte) {
-            Ok(1) => buf.push(byte[0]),
-            Ok(_) => continue,
-            Err(ref e) if e.kind() == std::io::ErrorKind::TimedOut => continue,
-            Err(e) => return Err(format!("serial read error: {e}")),
-        }
-
-        // Need at least magic(2) + type(1) + len(2) + crc(4) = 9 bytes
-        if buf.len() < 9 {
-            continue;
-        }
-
-        // Scan for magic bytes
-        if buf[0] != FRAME_MAGIC[0] || buf[1] != FRAME_MAGIC[1] {
-            buf.drain(0..1);
-            continue;
-        }
-
-        let frame_type = buf[2];
-        let payload_len = u16::from_be_bytes([buf[3], buf[4]]) as usize;
-        let total = 2 + 1 + 2 + payload_len + 4;
-
-        if buf.len() < total {
-            continue;
-        }
-
-        // Verify CRC over everything except the trailing 4-byte CRC itself
-        let expected_crc =
-            u32::from_be_bytes([buf[total - 4], buf[total - 3], buf[total - 2], buf[total - 1]]);
-        // CRC covers type + length + payload, NOT the 2 magic bytes.
-        let actual_crc = crc32fast::hash(&buf[FRAME_MAGIC.len()..total - 4]);
-        if actual_crc != expected_crc {
-            return Err("CRC mismatch in ESP32 response".to_string());
-        }
-
-        // Payload starts after the 5-byte header (magic 2 + type 1 + len 2).
-        let payload = buf[5..total - 4].to_vec();
-        return Ok((frame_type, payload));
-    }
-}
+// The serial frame codec (build_frame / read_frame / the frame-type
+// constants) now lives in the shared `heartwood-frame` crate, imported at the
+// top of this file. Both host binaries share that single copy, so the wire
+// format cannot drift between them.
 
 #[derive(Deserialize)]
 struct HsmPinRequest {
@@ -1952,7 +1880,8 @@ async fn api_hsm_pin(
             .map_err(|e| format!("failed to write to serial port: {e}"))?;
 
         // Wait for ACK/NACK — the user has up to 30 seconds to press the button
-        let (frame_type, _) = read_frame(&mut *port, std::time::Duration::from_secs(35))?;
+        let (frame_type, _) = read_frame(&mut *port, std::time::Duration::from_secs(35))
+            .map_err(|e| e.to_string())?;
 
         match frame_type {
             FRAME_TYPE_ACK => Ok(()),
@@ -2274,70 +2203,5 @@ mod tests {
         assert!(!is_valid_pair_name("has spaces"));
         assert!(!is_valid_pair_name("has/slash"));
         assert!(!is_valid_pair_name(&"a".repeat(65)));
-    }
-
-    // --- serial frame codec (the /api/hsm/pin transport) -----------------
-
-    #[test]
-    fn read_frame_returns_empty_payload_ack_without_panicking() {
-        // Regression: the firmware ACKs SET_PIN with an EMPTY payload (a 9-byte
-        // frame). The old `buf[7..total - 4]` slice became `buf[7..5]` — a
-        // reversed range that panicked on every successful PIN operation. The
-        // correct header is 5 bytes, so the payload slice must start at 5.
-        let frame = build_frame(FRAME_TYPE_ACK, &[]);
-        let mut reader = frame.as_slice();
-        let (ty, payload) =
-            read_frame(&mut reader, std::time::Duration::from_secs(1)).expect("must not panic");
-        assert_eq!(ty, FRAME_TYPE_ACK);
-        assert!(payload.is_empty());
-    }
-
-    #[test]
-    fn read_frame_recovers_the_full_payload() {
-        // The old offset silently dropped the first two payload bytes; assert
-        // every byte survives the round trip.
-        let payload = b"npub1exampledata";
-        let frame = build_frame(0x07, payload);
-        let mut reader = frame.as_slice();
-        let (ty, got) =
-            read_frame(&mut reader, std::time::Duration::from_secs(1)).expect("reads a frame");
-        assert_eq!(ty, 0x07);
-        assert_eq!(got, payload);
-    }
-
-    #[test]
-    fn read_frame_skips_boot_banner_noise() {
-        let mut bytes = b"esp32 ready\r\n".to_vec();
-        assert!(!bytes.windows(2).any(|w| w[0] == FRAME_MAGIC[0] && w[1] == FRAME_MAGIC[1]));
-        bytes.extend_from_slice(&build_frame(FRAME_TYPE_NACK, &[]));
-        let mut reader = bytes.as_slice();
-        let (ty, payload) =
-            read_frame(&mut reader, std::time::Duration::from_secs(1)).expect("reads a frame");
-        assert_eq!(ty, FRAME_TYPE_NACK);
-        assert!(payload.is_empty());
-    }
-
-    #[test]
-    fn read_frame_rejects_crc_corruption() {
-        let mut frame = build_frame(FRAME_TYPE_SET_PIN, b"1234");
-        let last = frame.len() - 1;
-        frame[last] ^= 0xff; // corrupt the trailing CRC
-        let mut reader = frame.as_slice();
-        assert!(read_frame(&mut reader, std::time::Duration::from_secs(1)).is_err());
-    }
-
-    #[test]
-    fn build_frame_crc_excludes_the_magic() {
-        // This is a second copy of the bridge's frame codec; pin the CRC scheme
-        // so the two cannot drift (a mismatch silently breaks the wire format
-        // against real firmware — the exact bug fixed when the bridge landed).
-        let payload = b"abc";
-        let frame = build_frame(FRAME_TYPE_SET_PIN, payload);
-        let crc = u32::from_be_bytes([frame[8], frame[9], frame[10], frame[11]]);
-        let mut hasher = crc32fast::Hasher::new();
-        hasher.update(&[FRAME_TYPE_SET_PIN]);
-        hasher.update(&(payload.len() as u16).to_be_bytes());
-        hasher.update(payload);
-        assert_eq!(crc, hasher.finalize(), "CRC must exclude the 2 magic bytes");
     }
 }

--- a/crates/heartwood-frame/Cargo.toml
+++ b/crates/heartwood-frame/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "heartwood-frame"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Binary serial frame codec shared by the Heartwood host binaries (the relay-serial bridge and the Pi web device)"
+keywords = ["nostr", "serial", "esp32", "framing"]
+publish = false
+
+[dependencies]
+crc32fast = "1"

--- a/crates/heartwood-frame/src/lib.rs
+++ b/crates/heartwood-frame/src/lib.rs
@@ -8,14 +8,17 @@
 //!
 //! The CRC covers the **type, length and payload only — NOT the magic
 //! preamble**, matching the firmware in `heartwood-esp32`
-//! (`common/src/frame.rs`). (Note: `heartwood-device`'s in-file web serial
-//! codec hashes *including* the magic, which is incompatible with the device;
-//! this codec follows the firmware, which is authoritative.) The frame-type
-//! constants below are a subset of `heartwood-esp32`'s `common/src/types.rs`.
+//! (`common/src/frame.rs`), which is authoritative. The frame-type constants
+//! below are the subset used by the two host binaries — the relay-serial
+//! bridge and the Pi web device — drawn from `heartwood-esp32`'s
+//! `common/src/types.rs`.
+//!
+//! This crate exists so those two binaries share **one** codec rather than
+//! keeping (drifting) copies. A third copy lives in the firmware, which is
+//! `no_std` and owns the canonical definition; the host side mirrors it and is
+//! pinned to the same scheme by the tests below.
 
 use std::time::{Duration, Instant};
-
-use anyhow::{bail, Result};
 
 /// Frame preamble: ASCII "HW".
 pub const FRAME_MAGIC: [u8; 2] = [0x48, 0x57];
@@ -26,16 +29,67 @@ pub const HEADER_LEN: usize = 2 + 1 + 2;
 /// Fixed overhead around a payload: header(5) + crc(4).
 pub const FRAME_OVERHEAD: usize = HEADER_LEN + 4;
 
-// --- Frame types the bridge uses (subset of the firmware's full set) ---
-pub const FRAME_TYPE_NACK: u8 = 0x15;
+// --- Frame types (subset of the firmware's full set in common/src/types.rs) ---
 pub const FRAME_TYPE_PROVISION_LIST: u8 = 0x05;
+pub const FRAME_TYPE_ACK: u8 = 0x06;
 pub const FRAME_TYPE_PROVISION_LIST_RESPONSE: u8 = 0x07;
 pub const FRAME_TYPE_ENCRYPTED_REQUEST: u8 = 0x10;
+pub const FRAME_TYPE_NACK: u8 = 0x15;
 pub const FRAME_TYPE_SESSION_AUTH: u8 = 0x21;
 pub const FRAME_TYPE_SESSION_ACK: u8 = 0x22;
+pub const FRAME_TYPE_SET_PIN: u8 = 0x25;
 pub const FRAME_TYPE_SIGN_ENVELOPE_RESPONSE: u8 = 0x35;
 pub const FRAME_TYPE_FIRMWARE_INFO: u8 = 0x59;
 pub const FRAME_TYPE_FIRMWARE_INFO_RESPONSE: u8 = 0x5A;
+
+/// Anything that can go wrong reading or parsing a frame.
+#[derive(Debug)]
+pub enum FrameError {
+    /// The buffer is smaller than the fixed frame overhead.
+    TooShort(usize),
+    /// The magic preamble was wrong.
+    BadMagic,
+    /// The buffer length does not match the length the header declared.
+    LengthMismatch { expected: usize, actual: usize },
+    /// The trailing CRC did not match the recomputed CRC.
+    CrcMismatch { expected: u32, actual: u32 },
+    /// No complete frame arrived before the deadline.
+    Timeout,
+    /// The underlying reader returned an error.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for FrameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FrameError::TooShort(n) => write!(f, "frame buffer too short ({n} bytes)"),
+            FrameError::BadMagic => write!(f, "bad frame magic"),
+            FrameError::LengthMismatch { expected, actual } => {
+                write!(f, "frame length mismatch: header says {expected}, got {actual}")
+            }
+            FrameError::CrcMismatch { expected, actual } => {
+                write!(f, "CRC mismatch (expected {expected:#010x}, got {actual:#010x})")
+            }
+            FrameError::Timeout => write!(f, "timed out waiting for a frame from the device"),
+            FrameError::Io(e) => write!(f, "serial read error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for FrameError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            FrameError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for FrameError {
+    fn from(e: std::io::Error) -> Self {
+        FrameError::Io(e)
+    }
+}
 
 /// Build a framed serial message ready to write to the port.
 pub fn build_frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
@@ -54,26 +108,27 @@ pub fn build_frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
 ///
 /// `buf` must start at the magic bytes and contain one whole frame (the caller
 /// computes the length from the header). Returns `(frame_type, payload)`.
-pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>)> {
+pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>), FrameError> {
     if buf.len() < FRAME_OVERHEAD {
-        bail!("frame buffer too short ({} bytes)", buf.len());
+        return Err(FrameError::TooShort(buf.len()));
     }
     if buf[0] != FRAME_MAGIC[0] || buf[1] != FRAME_MAGIC[1] {
-        bail!("bad frame magic");
+        return Err(FrameError::BadMagic);
     }
     let frame_type = buf[2];
     let payload_len = u16::from_be_bytes([buf[3], buf[4]]) as usize;
     let total = FRAME_OVERHEAD + payload_len;
     if buf.len() != total {
-        bail!("frame length mismatch: header says {total}, got {}", buf.len());
+        return Err(FrameError::LengthMismatch { expected: total, actual: buf.len() });
     }
     let expected =
         u32::from_be_bytes([buf[total - 4], buf[total - 3], buf[total - 2], buf[total - 1]]);
     // CRC covers type + length + payload, but NOT the 2 magic bytes.
     let actual = crc32fast::hash(&buf[FRAME_MAGIC.len()..total - 4]);
     if actual != expected {
-        bail!("CRC mismatch (expected {expected:#010x}, got {actual:#010x})");
+        return Err(FrameError::CrcMismatch { expected, actual });
     }
+    // Payload starts after the 5-byte header (magic 2 + type 1 + len 2).
     Ok((frame_type, buf[HEADER_LEN..total - 4].to_vec()))
 }
 
@@ -81,31 +136,31 @@ pub fn parse_complete(buf: &[u8]) -> Result<(u8, Vec<u8>)> {
 ///
 /// Bytes are accumulated and resynchronised on the magic preamble, so stray
 /// bytes before a frame (e.g. a boot banner) are skipped rather than fatal.
+/// Per-read `TimedOut`/`WouldBlock` results just mean "nothing yet" and the
+/// read keeps waiting until the overall deadline.
 pub fn read_frame<R: std::io::Read + ?Sized>(
     port: &mut R,
     timeout: Duration,
-) -> Result<(u8, Vec<u8>)> {
+) -> Result<(u8, Vec<u8>), FrameError> {
     let deadline = Instant::now() + timeout;
     let mut buf: Vec<u8> = Vec::with_capacity(128);
 
     loop {
         if Instant::now() >= deadline {
-            bail!("timed out waiting for a frame from the device");
+            return Err(FrameError::Timeout);
         }
 
         let mut byte = [0u8; 1];
         match std::io::Read::read(port, &mut byte) {
             Ok(1) => buf.push(byte[0]),
             Ok(_) => continue,
-            // A read timeout (serial ports) or WouldBlock (sockets with a read
-            // timeout) just means "nothing yet" — keep waiting until the deadline.
             Err(ref e)
                 if e.kind() == std::io::ErrorKind::TimedOut
                     || e.kind() == std::io::ErrorKind::WouldBlock =>
             {
                 continue
             }
-            Err(e) => return Err(anyhow::Error::new(e).context("serial read error")),
+            Err(e) => return Err(FrameError::Io(e)),
         }
 
         // Need at least the header to know the total length.
@@ -134,7 +189,6 @@ mod tests {
     fn build_then_parse_round_trips() {
         let payload = b"hello device";
         let frame = build_frame(FRAME_TYPE_ENCRYPTED_REQUEST, payload);
-        // magic(2)+type(1)+len(2)+payload(12)+crc(4)
         assert_eq!(frame.len(), FRAME_OVERHEAD + payload.len());
         let (ty, got) = parse_complete(&frame).unwrap();
         assert_eq!(ty, FRAME_TYPE_ENCRYPTED_REQUEST);
@@ -152,23 +206,31 @@ mod tests {
     #[test]
     fn corrupt_payload_fails_crc() {
         let mut frame = build_frame(FRAME_TYPE_NACK, b"abc");
-        let mid = 6; // somewhere in the payload
-        frame[mid] ^= 0xff;
-        assert!(parse_complete(&frame).is_err());
+        frame[6] ^= 0xff; // somewhere in the payload
+        assert!(matches!(parse_complete(&frame), Err(FrameError::CrcMismatch { .. })));
     }
 
     #[test]
     fn bad_magic_rejected() {
         let mut frame = build_frame(FRAME_TYPE_NACK, b"x");
         frame[0] = 0x00;
-        assert!(parse_complete(&frame).is_err());
+        assert!(matches!(parse_complete(&frame), Err(FrameError::BadMagic)));
+    }
+
+    #[test]
+    fn length_mismatch_rejected() {
+        let frame = build_frame(FRAME_TYPE_NACK, b"abc");
+        // Hand the parser one byte too few: the header claims more than is present.
+        assert!(matches!(
+            parse_complete(&frame[..frame.len() - 1]),
+            Err(FrameError::LengthMismatch { .. })
+        ));
     }
 
     #[test]
     fn crc_excludes_magic_matching_firmware() {
-        // The firmware (heartwood-esp32 common/src/frame.rs) hashes
-        // type + length + payload, NOT the magic preamble. Pin that exact
-        // scheme so the bridge stays wire-compatible with real hardware.
+        // The firmware hashes type + length + payload, NOT the magic preamble.
+        // Pin that exact scheme so the host stays wire-compatible with hardware.
         let frame_type = FRAME_TYPE_ENCRYPTED_REQUEST;
         let payload = b"abc";
         let frame = build_frame(frame_type, payload);
@@ -266,7 +328,35 @@ mod tests {
     #[test]
     fn read_frame_times_out_when_silent() {
         let mut reader = DribbleReader::bytes(b""); // immediately drained → TimedOut
-        let err = read_frame(&mut reader, Duration::from_millis(80)).unwrap_err().to_string();
-        assert!(err.contains("timed out"), "{err}");
+        assert!(matches!(
+            read_frame(&mut reader, Duration::from_millis(80)),
+            Err(FrameError::Timeout)
+        ));
+    }
+
+    // --- regression: the device /api/hsm/pin payload-offset bug -----------
+
+    #[test]
+    fn read_frame_returns_empty_payload_without_panicking() {
+        // The firmware ACKs SET_PIN with an EMPTY payload (a 9-byte frame). A
+        // payload offset of 7 instead of 5 made the slice `buf[7..5]` — a
+        // reversed range that panicked on every PIN operation. Guard it.
+        let frame = build_frame(FRAME_TYPE_ACK, &[]);
+        let mut reader = frame.as_slice();
+        let (ty, payload) = read_frame(&mut reader, Duration::from_secs(1)).unwrap();
+        assert_eq!(ty, FRAME_TYPE_ACK);
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn read_frame_recovers_the_full_payload() {
+        // The buggy offset silently dropped the first two payload bytes; assert
+        // every byte survives the round trip.
+        let payload = b"npub1exampledata";
+        let frame = build_frame(FRAME_TYPE_PROVISION_LIST_RESPONSE, payload);
+        let mut reader = frame.as_slice();
+        let (ty, got) = read_frame(&mut reader, Duration::from_secs(1)).unwrap();
+        assert_eq!(ty, FRAME_TYPE_PROVISION_LIST_RESPONSE);
+        assert_eq!(got, payload);
     }
 }


### PR DESCRIPTION
## Summary

Retires the serial-frame-codec duplication inside the workspace. The codec lived as two near-identical copies — `heartwood-bridge/src/frame.rs` and an inline copy in `heartwood-device/src/web.rs` — which had **already drifted once** (the `web.rs` `read_frame` payload-offset bug fixed in #13). This collapses them into one `heartwood-frame` crate both binaries depend on, so the wire format can't diverge again.

## Changes

- **New `crates/heartwood-frame`** — `build_frame` / `parse_complete` / `read_frame`, a `FrameError` type (replacing the bridge's `anyhow` context and the device's `String` errors), the **union** of both crates' frame-type constants, and the consolidated test suite (round-trips, `read_frame` reassembly / boot-banner resync / `WouldBlock`+`TimedOut` stalls / timeout, and the empty- and full-payload offset regressions).
- **`heartwood-bridge`** — delete `src/frame.rs`; depend on `heartwood-frame`; map `FrameError` → `anyhow` via `?`.
- **`heartwood-device`** — delete the inline codec from `web.rs`; depend on `heartwood-frame`; map `FrameError` → `String` for the `/api/hsm/pin` task.
- Drop the now-unused direct `crc32fast` dep from both binaries (it moves into `heartwood-frame`).

The firmware's third copy (`heartwood-esp32 common/src/frame.rs`, `no_std`, separate repo) stays the canonical authority; the host crate mirrors it.

**Behaviour note:** the `/api/hsm/pin` *error strings* change slightly (e.g. "timed out waiting for a frame from the device"); the wire format and happy path are byte-identical.

## Test

Full workspace green — **33 bridge + 31 device + 12 frame** · `fmt` clean · `clippy` clean · net roughly −400 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
