### PR TITLE
test: cover the relay message handler

### DIFF
--- a/crates/heartwood-bridge/src/relay.rs
+++ b/crates/heartwood-bridge/src/relay.rs
@@ -172,3 +172,114 @@ async fn handle_relay_message(
 fn short(hex: &str) -> &str {
     &hex[..hex.len().min(12)]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::sync::mpsc;
+
+    const MASTER: &str = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d";
+    const OTHER_MASTER: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+    const CLIENT: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+
+    /// `["EVENT", sub, {…}]` addressed (`p` tag) to `master`.
+    fn event_msg(kind: u64, master: &str, id: impl AsRef<str>) -> String {
+        json!(["EVENT", "sub", {
+            "id": id.as_ref(),
+            "pubkey": CLIENT,
+            "created_at": 1_700_000_000u64,
+            "kind": kind,
+            "tags": [["p", master]],
+            "content": "AgCipherTextBase64==",
+            "sig": "ff".repeat(64),
+        }])
+        .to_string()
+    }
+
+    /// masters = [MASTER]; a fresh dedup set; a job channel to observe dispatch.
+    fn harness() -> (Vec<String>, Seen, mpsc::Sender<RequestJob>, mpsc::Receiver<RequestJob>) {
+        let (tx, rx) = mpsc::channel(8);
+        (vec![MASTER.to_string()], Seen::new(64), tx, rx)
+    }
+
+    #[tokio::test]
+    async fn valid_request_for_our_master_queues_exactly_one_job() {
+        let (masters, seen, tx, mut rx) = harness();
+        let msg = event_msg(NIP46_KIND, MASTER, "a".repeat(64));
+        handle_relay_message(&msg, "ws://t", &masters, &seen, &tx).await;
+
+        let job = rx.try_recv().expect("a job should be queued");
+        assert_eq!(job.request.master_pubkey_hex, MASTER);
+        assert_eq!(job.request.client_pubkey_hex, CLIENT);
+        assert_eq!(job.request.content, "AgCipherTextBase64==");
+        assert!(rx.try_recv().is_err(), "exactly one job");
+    }
+
+    #[tokio::test]
+    async fn duplicate_id_from_a_second_relay_is_not_requeued() {
+        // The same request usually arrives from several relays at once; the
+        // device must sign it once. Same id, two relays -> one job.
+        let (masters, seen, tx, mut rx) = harness();
+        let msg = event_msg(NIP46_KIND, MASTER, "b".repeat(64));
+        handle_relay_message(&msg, "ws://relay-a", &masters, &seen, &tx).await;
+        handle_relay_message(&msg, "ws://relay-b", &masters, &seen, &tx).await;
+
+        assert!(rx.try_recv().is_ok(), "first sighting queues a job");
+        assert!(rx.try_recv().is_err(), "the duplicate must be dropped");
+    }
+
+    #[tokio::test]
+    async fn event_for_a_master_we_do_not_hold_is_ignored() {
+        let (masters, seen, tx, mut rx) = harness();
+        let msg = event_msg(NIP46_KIND, OTHER_MASTER, "c".repeat(64));
+        handle_relay_message(&msg, "ws://t", &masters, &seen, &tx).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn non_nip46_kind_is_ignored() {
+        let (masters, seen, tx, mut rx) = harness();
+        let msg = event_msg(1, MASTER, "d".repeat(64));
+        handle_relay_message(&msg, "ws://t", &masters, &seen, &tx).await;
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn an_id_less_request_is_let_through_not_swallowed() {
+        // dedup can't key an id-less event, so the handler must forward it
+        // rather than silently drop it.
+        let (masters, seen, tx, mut rx) = harness();
+        let msg = json!(["EVENT", "sub", {
+            "pubkey": CLIENT,
+            "created_at": 1_700_000_000u64,
+            "kind": NIP46_KIND,
+            "tags": [["p", MASTER]],
+            "content": "AgCipherTextBase64==",
+            "sig": "ff".repeat(64),
+        }])
+        .to_string();
+        handle_relay_message(&msg, "ws://t", &masters, &seen, &tx).await;
+        assert!(rx.try_recv().is_ok(), "an id-less request is still dispatched");
+    }
+
+    #[tokio::test]
+    async fn protocol_noise_and_garbage_queue_nothing() {
+        let (masters, seen, tx, mut rx) = harness();
+        for msg in [
+            r#"["EOSE","sub"]"#,
+            r#"["OK","id",false,"blocked: pow"]"#,
+            r#"["OK","id",true]"#,
+            r#"["NOTICE","hello"]"#,
+            r#"["CLOSED","sub","bye"]"#,
+            r#"["EVENT","sub"]"#, // EVENT verb but no event element
+            r#"not json at all"#,
+            r#"{"not":"an array"}"#,
+            r#"[]"#,
+            r#"["EVENT","sub",{"kind":24133,"tags":[["p","short"]],"pubkey":"x"}]"#, // for nobody
+        ] {
+            handle_relay_message(msg, "ws://t", &masters, &seen, &tx).await;
+        }
+        assert!(rx.try_recv().is_err(), "no job from any non-request message");
+    }
+}


### PR DESCRIPTION
## Summary

`handle_relay_message` — the bridge's request-ingestion core (filters EVENTs by kind + master, de-duplicates across relays, dispatches signing jobs) — had **zero direct unit tests**; only the single happy-path e2e touched it. A bug there silently drops, duplicates, or misroutes signing requests.

## Tests

Six `#[tokio::test]` cases drive the handler with crafted relay messages and assert on the dispatched job channel:

- a valid kind:24133 request for our master queues **exactly one** job (right fields)
- the same id from a second relay is **de-duplicated** — one job, not two (the whole point of `Seen`)
- an event addressed to a master we don't hold is ignored (`#p` routing)
- a non-NIP-46 kind is ignored
- an **id-less** request is forwarded, not swallowed (matches the dedup "can't key it → don't drop it" rule)
- protocol noise and garbage (EOSE / OK / CLOSED / NOTICE, bad JSON, non-arrays, a truncated EVENT) queue nothing and never panic

Tests only; no behaviour change. Bridge suite **33 → 39**; `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
