### PR TITLE
feat: per-identity bunker connections (one URI per identity)

### DIFF
--- a/bunker/index.mjs
+++ b/bunker/index.mjs
@@ -12,7 +12,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { getConversationKey, encrypt, decrypt } from 'nostr-tools/nip44'
 import { finalizeEvent, getPublicKey, generateSecretKey } from 'nostr-tools/pure'
-import { decode as nip19decode } from 'nostr-tools/nip19'
+import { decode as nip19decode, npubEncode } from 'nostr-tools/nip19'
 import { SimplePool } from 'nostr-tools/pool'
 import WebSocket from 'ws'
 import { fromNsec } from 'nsec-tree/core'
@@ -174,34 +174,24 @@ const personasPath = `${DATA_DIR}/personas.json`
 let personas = loadJson(personasPath, [])
 
 /**
- * Active signing identity. Null means the master key (userSk/userPk).
- * When set, points to a persona entry whose key is used for signing.
+ * Resolve the identity a NIP-46 request was addressed to — its remote-signer
+ * pubkey, i.e. the event's `#p` target. Each identity's own key serves as both
+ * the NIP-44 transport key and the event-signing key, so one connection maps to
+ * exactly one identity (there is no global "active" pointer).
+ *
+ * Returns `{ sk, pk, ephemeral }`, or `null` if `targetHex` is not an identity
+ * we serve. Persona keys are re-derived on demand; pass the result to
+ * `releaseKey()` after use to zero the derived key material.
  */
-let activePersonaPubkey = null
-
-// Restore active persona from config
-const personaConfigPath = `${DATA_DIR}/active-persona.json`
-const personaConfig = loadJson(personaConfigPath, {})
-if (personaConfig.activePubkey) {
-  activePersonaPubkey = personaConfig.activePubkey
-}
-
-/**
- * Get the currently active signing key and pubkey.
- * When a persona is active, the private key is re-derived on each call.
- * Call `releaseKey(result)` after use to zero derived key material.
- */
-function getActiveSigningKey() {
-  if (!activePersonaPubkey) {
+function resolveIdentity(targetHex) {
+  if (targetHex === userPk) {
     return { sk: userSk, pk: userPk, ephemeral: false }
   }
-  const persona = personas.find((p) => p.pubkey === activePersonaPubkey)
+  const persona = personas.find((p) => p.pubkey === targetHex)
   if (!persona) {
-    // Persona was removed — fall back to master
-    activePersonaPubkey = null
-    return { sk: userSk, pk: userPk, ephemeral: false }
+    return null
   }
-  // Re-derive the private key from the tree root
+  // Re-derive the persona's private key from the tree root.
   const derived = derivePersona(treeRoot, persona.name, persona.index)
   return {
     sk: derived.identity.privateKey,
@@ -319,8 +309,6 @@ if (existsSync(bunkerKeyPath)) {
   console.log('Generated new bunker keypair')
 }
 
-const bunkerPk = getPublicKey(bunkerSk)
-
 // --- 4. Connect to relays and subscribe ---
 
 const pool = new SimplePool()
@@ -328,13 +316,43 @@ const pool = new SimplePool()
 /** Active subscription handle, tracked so we can close it on relay change. */
 let activeSub = null
 
-/** Build a bunker URI from the bunker pubkey and relay list. */
-function buildBunkerUri(relayList) {
-  const params = relayList.map((r) => `relay=${encodeURIComponent(r)}`).join('&')
-  return `bunker://${bunkerPk}?${params}`
+/** Hex pubkeys of every identity we currently serve: master + all personas. */
+function servedPubkeys() {
+  return [userPk, ...personas.map((p) => p.pubkey)]
 }
 
-/** Write the bunker URI file and subscribe to the given relays. */
+/** Build a bunker URI addressed to a specific identity pubkey. */
+function buildBunkerUri(pubkeyHex, relayList) {
+  const params = relayList.map((r) => `relay=${encodeURIComponent(r)}`).join('&')
+  return `bunker://${pubkeyHex}?${params}`
+}
+
+/**
+ * Persist the per-identity bunker URIs and return the master URI.
+ *  - `bunker-uri.txt`   the master URI (the device's /api/status still reads this)
+ *  - `bunker-uris.json` `[{ label, pubkey, npub, uri }]` for master + every persona
+ */
+function writeBunkerUris(relayList) {
+  const masterUri = buildBunkerUri(userPk, relayList)
+  writeFileSync(`${DATA_DIR}/bunker-uri.txt`, masterUri, { mode: 0o600 })
+
+  const manifest = [
+    { label: 'master', pubkey: userPk, npub: npubEncode(userPk), uri: masterUri },
+    ...personas.map((p) => ({
+      label: p.name,
+      pubkey: p.pubkey,
+      npub: npubEncode(p.pubkey),
+      uri: buildBunkerUri(p.pubkey, relayList),
+    })),
+  ]
+  writeFileSync(`${DATA_DIR}/bunker-uris.json`, JSON.stringify(manifest, null, 2), {
+    mode: 0o600,
+  })
+
+  return masterUri
+}
+
+/** Subscribe for requests to every served identity, then (re)write the URIs. */
 function connectRelays(relayList) {
   // Close any existing subscription before reconnecting
   if (activeSub) {
@@ -344,7 +362,7 @@ function connectRelays(relayList) {
 
   activeSub = pool.subscribe(
     relayList,
-    { kinds: [24133], '#p': [bunkerPk] },
+    { kinds: [24133], '#p': servedPubkeys() },
     {
       onevent: async (event) => {
         try {
@@ -356,11 +374,8 @@ function connectRelays(relayList) {
     },
   )
 
-  // Recompute and persist the bunker URI
-  const bunkerUri = buildBunkerUri(relayList)
-  writeFileSync(`${DATA_DIR}/bunker-uri.txt`, bunkerUri, { mode: 0o600 })
-
-  return bunkerUri
+  // Recompute and persist the per-identity bunker URIs.
+  return writeBunkerUris(relayList)
 }
 
 // --- 5. Write bunker URI and start initial subscription ---
@@ -403,8 +418,25 @@ function recordSlotClient(secret, clientPk) {
 // --- 6. Request handler ---
 
 async function handleRequest(event) {
+  // Route by the request's `#p` target: every identity has its own bunker URI
+  // and signs with its own key. Resolve once here; release the derived key in
+  // the `finally` below.
+  const targetTag = event.tags.find((t) => Array.isArray(t) && t[0] === 'p')
+  const identity = targetTag ? resolveIdentity(targetTag[1]) : null
+  if (!identity) {
+    // Not addressed to an identity we serve (unknown or stale persona) — ignore.
+    return
+  }
+  try {
+    await handleRequestForIdentity(event, identity)
+  } finally {
+    releaseKey(identity)
+  }
+}
+
+async function handleRequestForIdentity(event, identity) {
   const clientPk = event.pubkey
-  const conversationKey = getConversationKey(bunkerSk, clientPk)
+  const conversationKey = getConversationKey(identity.sk, clientPk)
 
   let request
   try {
@@ -444,7 +476,7 @@ async function handleRequest(event) {
             tags: [['p', clientPk]],
             content: encrypted,
           },
-          bunkerSk,
+          identity.sk,
         )
         await Promise.any(pool.publish(relays, responseEvent))
         return
@@ -468,7 +500,7 @@ async function handleRequest(event) {
           tags: [['p', clientPk]],
           content: encrypted,
         },
-        bunkerSk,
+        identity.sk,
       )
       await Promise.any(pool.publish(relays, responseEvent))
       return
@@ -511,9 +543,7 @@ async function handleRequest(event) {
       break
 
     case 'get_public_key': {
-      const active = getActiveSigningKey()
-      result = active.pk
-      releaseKey(active)
+      result = identity.pk
       break
     }
 
@@ -543,13 +573,8 @@ async function handleRequest(event) {
         error = `signing kind ${template.kind} not permitted for this client`
         break
       }
-      const active = getActiveSigningKey()
-      try {
-        const signed = finalizeEvent(template, active.sk)
-        result = JSON.stringify(signed)
-      } finally {
-        releaseKey(active)
-      }
+      const signed = finalizeEvent(template, identity.sk)
+      result = JSON.stringify(signed)
       break
     }
 
@@ -562,13 +587,8 @@ async function handleRequest(event) {
         error = 'nip44_encrypt: peer_pubkey must be a 64-character hex string'
         break
       }
-      const active = getActiveSigningKey()
-      try {
-        const ck = getConversationKey(active.sk, request.params[0])
-        result = encrypt(request.params[1], ck)
-      } finally {
-        releaseKey(active)
-      }
+      const ck = getConversationKey(identity.sk, request.params[0])
+      result = encrypt(request.params[1], ck)
       break
     }
 
@@ -581,13 +601,8 @@ async function handleRequest(event) {
         error = 'nip44_decrypt: peer_pubkey must be a 64-character hex string'
         break
       }
-      const active = getActiveSigningKey()
-      try {
-        const ck = getConversationKey(active.sk, request.params[0])
-        result = decrypt(request.params[1], ck)
-      } finally {
-        releaseKey(active)
-      }
+      const ck = getConversationKey(identity.sk, request.params[0])
+      result = decrypt(request.params[1], ck)
       break
     }
 
@@ -632,33 +647,19 @@ async function handleRequest(event) {
       const record = { name, pubkey, purpose: derived.identity.purpose, index: derived.index }
       personas.push(record)
       saveJson(personasPath, personas)
-      console.log(`Derived persona "${name}" → ${pubkey.slice(0, 12)}...`)
+      // Serve the new persona immediately: re-subscribe (the filter now includes
+      // its pubkey) and refresh the per-identity bunker URIs.
+      connectRelays(relays)
+      console.log(`Derived persona "${name}" → ${pubkey.slice(0, 12)}... (now reachable)`)
       result = JSON.stringify(record)
       break
     }
 
     case 'heartwood_switch': {
-      const targetPubkey = request.params[0]
-      if (typeof targetPubkey !== 'string' || targetPubkey.length === 0) {
-        error = 'heartwood_switch: target must be a non-empty string'
-        break
-      }
-      if (targetPubkey === userPk) {
-        // Switch back to master
-        activePersonaPubkey = null
-        saveJson(personaConfigPath, { activePubkey: null })
-        result = JSON.stringify({ switched: true, pubkey: userPk, name: 'master' })
-        break
-      }
-      const target = personas.find((p) => p.pubkey === targetPubkey)
-      if (!target) {
-        error = `unknown persona: ${targetPubkey.slice(0, 12)}...`
-        break
-      }
-      activePersonaPubkey = targetPubkey
-      saveJson(personaConfigPath, { activePubkey: targetPubkey })
-      console.log(`Switched to persona "${target.name}" (${targetPubkey.slice(0, 12)}...)`)
-      result = JSON.stringify({ switched: true, pubkey: targetPubkey, name: target.name })
+      // Legacy no-op. Identity is now selected per-connection by the bunker URI
+      // the client connected to (the request's `#p` target), so there is no
+      // global "active" identity to switch. Report the connection's identity.
+      result = JSON.stringify({ switched: true, pubkey: identity.pk })
       break
     }
 
@@ -689,21 +690,36 @@ async function handleRequest(event) {
         error = 'heartwood_lsag_sign: signerIndex out of range'
         break
       }
-      const lsagActive = getActiveSigningKey()
-      try {
-        const skHex = typeof lsagActive.sk === 'string' ? lsagActive.sk : bytesToHex(lsagActive.sk)
-        const sig = domain
-          ? lsagSign(message, ring, signerIndex, skHex, electionId, domain)
-          : lsagSign(message, ring, signerIndex, skHex, electionId)
-        result = JSON.stringify({
-          signature: sig,
-          keyImage: sig.keyImage,
-          publicKey: lsagActive.pk,
-        })
-        console.log(`LSAG signed: ring=${ring.length}, index=${signerIndex}, pubkey=${lsagActive.pk.slice(0, 12)}...`)
-      } finally {
-        releaseKey(lsagActive)
+      const skHex = typeof identity.sk === 'string' ? identity.sk : bytesToHex(identity.sk)
+      const sig = domain
+        ? lsagSign(message, ring, signerIndex, skHex, electionId, domain)
+        : lsagSign(message, ring, signerIndex, skHex, electionId)
+      result = JSON.stringify({
+        signature: sig,
+        keyImage: sig.keyImage,
+        publicKey: identity.pk,
+      })
+      console.log(`LSAG signed: ring=${ring.length}, index=${signerIndex}, pubkey=${identity.pk.slice(0, 12)}...`)
+      break
+    }
+
+    case 'switch_relays': {
+      // Some clients (e.g. Coracle/welshman) ask the signer to use a given set
+      // of relays for the session and stall until it succeeds. Union them into
+      // our relay set so we stay reachable on whatever relays the client uses,
+      // then acknowledge.
+      const requested = Array.isArray(request.params)
+        ? request.params.flat().filter((r) => typeof r === 'string' && /^wss?:\/\//.test(r))
+        : []
+      // Keep our configured relays first; cap the total so a client can't grow
+      // the set unboundedly.
+      const merged = [...new Set([...relays, ...requested])].slice(0, 16)
+      if (merged.length !== relays.length) {
+        relays = merged
+        connectRelays(relays)
+        console.log(`switch_relays: now serving on ${relays.join(', ')}`)
       }
+      result = 'ack'
       break
     }
 
@@ -724,7 +740,7 @@ async function handleRequest(event) {
       tags: [['p', clientPk]],
       content: encrypted,
     },
-    bunkerSk,
+    identity.sk,
   )
 
   await Promise.any(pool.publish(relays, responseEvent))

--- a/bunker/test/personas-integration.mjs
+++ b/bunker/test/personas-integration.mjs
@@ -1,0 +1,242 @@
+/**
+ * Integration test for per-identity bunker routing (approach B).
+ *
+ * Not run by `npm test` (no `.test.mjs` suffix) because it spawns the real
+ * sidecar and an in-process relay. Run directly:  node test/personas-integration.mjs
+ *
+ * It proves that each identity's bunker URI is an independent connection:
+ * connecting to identity X's URI yields X's pubkey from `get_public_key` and
+ * signs events as X — with no global "active" identity involved.
+ */
+
+import { spawn } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+import { WebSocketServer, WebSocket } from 'ws'
+import { generateSecretKey, getPublicKey, finalizeEvent, verifyEvent } from 'nostr-tools/pure'
+import { getConversationKey, encrypt, decrypt } from 'nostr-tools/nip44'
+import { bytesToHex } from 'nostr-tools/utils'
+import { fromMnemonic } from 'nsec-tree/mnemonic'
+import { derivePersona } from 'nsec-tree/persona'
+
+const BUNKER_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+// Standard BIP-39 test vector (well-known; test-only).
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const NIP46_KIND = 24133
+const nowSec = () => Math.floor(Date.now() / 1000)
+
+let failures = 0
+function check(cond, msg) {
+  if (cond) {
+    console.log(`  ✔ ${msg}`)
+  } else {
+    failures++
+    console.log(`  x FAIL: ${msg}`)
+  }
+}
+
+// ── Minimal in-process relay ────────────────────────────────────────────────
+function matchFilter(f, ev) {
+  if (f.kinds && !f.kinds.includes(ev.kind)) return false
+  if (f.authors && !f.authors.includes(ev.pubkey)) return false
+  if (f.ids && !f.ids.includes(ev.id)) return false
+  if (f.since && ev.created_at < f.since) return false
+  for (const k of Object.keys(f)) {
+    if (k[0] !== '#') continue
+    const want = f[k]
+    const tag = k.slice(1)
+    const have = ev.tags.filter((t) => t[0] === tag).map((t) => t[1])
+    if (!have.some((v) => want.includes(v))) return false
+  }
+  return true
+}
+
+function startRelay() {
+  const wss = new WebSocketServer({ port: 0 })
+  const recent = []
+  const subscribedPubkeys = new Set()
+  wss.on('connection', (ws) => {
+    ws._subs = new Map()
+    ws.on('message', (data) => {
+      let msg
+      try {
+        msg = JSON.parse(data)
+      } catch {
+        return
+      }
+      const [type, ...rest] = msg
+      if (type === 'REQ') {
+        const [subId, ...filters] = rest
+        ws._subs.set(subId, filters)
+        for (const f of filters) for (const p of f['#p'] ?? []) subscribedPubkeys.add(p)
+        for (const ev of recent) {
+          if (filters.some((f) => matchFilter(f, ev))) ws.send(JSON.stringify(['EVENT', subId, ev]))
+        }
+        ws.send(JSON.stringify(['EOSE', subId]))
+      } else if (type === 'EVENT') {
+        const ev = rest[0]
+        recent.push(ev)
+        if (recent.length > 300) recent.shift()
+        ws.send(JSON.stringify(['OK', ev.id, true, '']))
+        for (const client of wss.clients) {
+          if (client.readyState !== WebSocket.OPEN) continue
+          for (const [subId, filters] of client._subs ?? []) {
+            if (filters.some((f) => matchFilter(f, ev))) {
+              client.send(JSON.stringify(['EVENT', subId, ev]))
+              break
+            }
+          }
+        }
+      } else if (type === 'CLOSE') {
+        ws._subs.delete(rest[0])
+      }
+    })
+  })
+  const port = wss.address().port
+  return { wss, port, url: `ws://127.0.0.1:${port}`, subscribedPubkeys }
+}
+
+// ── Minimal NIP-46 client (one ws per call) ─────────────────────────────────
+function nip46Call(relayUrl, signerPk, clientSk, method, params, timeoutMs = 8000) {
+  return new Promise((resolve, reject) => {
+    const clientPk = getPublicKey(clientSk)
+    const convKey = getConversationKey(clientSk, signerPk)
+    const id = 'req' + Math.floor(Math.random() * 1e9)
+    const ws = new WebSocket(relayUrl)
+    const timer = setTimeout(() => {
+      ws.close()
+      reject(new Error(`timeout waiting for ${method} response`))
+    }, timeoutMs)
+    ws.on('open', () => {
+      ws.send(JSON.stringify(['REQ', 'r' + id, { kinds: [NIP46_KIND], '#p': [clientPk], authors: [signerPk] }]))
+      const content = encrypt(JSON.stringify({ id, method, params }), convKey)
+      const reqEvent = finalizeEvent(
+        { kind: NIP46_KIND, created_at: nowSec(), tags: [['p', signerPk]], content },
+        clientSk,
+      )
+      ws.send(JSON.stringify(['EVENT', reqEvent]))
+    })
+    ws.on('message', (data) => {
+      let msg
+      try {
+        msg = JSON.parse(data)
+      } catch {
+        return
+      }
+      if (msg[0] !== 'EVENT') return
+      const ev = msg[2]
+      if (ev.kind !== NIP46_KIND || ev.pubkey !== signerPk) return
+      let payload
+      try {
+        payload = JSON.parse(decrypt(ev.content, convKey))
+      } catch {
+        return
+      }
+      if (payload.id !== id) return
+      clearTimeout(timer)
+      ws.close()
+      if (payload.error) reject(new Error(payload.error))
+      else resolve(payload.result)
+    })
+    ws.on('error', (e) => {
+      clearTimeout(timer)
+      reject(e)
+    })
+  })
+}
+
+function parseBunkerUri(uri) {
+  const rest = uri.slice('bunker://'.length)
+  const [pubkey, query = ''] = rest.split('?')
+  const params = new URLSearchParams(query)
+  return { pubkey, relay: params.get('relay') }
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+async function main() {
+  const relay = startRelay()
+  const dataDir = mkdtempSync(join(tmpdir(), 'heartwood-bunker-test-'))
+  const clientSk = generateSecretKey()
+  const clientPk = getPublicKey(clientSk)
+
+  // Derive the two personas independently, so we can both pre-seed personas.json
+  // and assert the sidecar returns the SAME pubkeys.
+  const treeRoot = fromMnemonic(MNEMONIC)
+  const persona = (name) => {
+    const d = derivePersona(treeRoot, name, 0)
+    return { name, pubkey: bytesToHex(d.identity.publicKey), purpose: d.identity.purpose, index: d.index }
+  }
+  const personas = [persona('work'), persona('fun')]
+
+  writeFileSync(join(dataDir, 'master.payload'), `tree-mnemonic::${MNEMONIC}`)
+  writeFileSync(join(dataDir, 'config.json'), JSON.stringify({ relays: [relay.url] }))
+  writeFileSync(join(dataDir, 'personas.json'), JSON.stringify(personas))
+
+  const child = spawn('node', ['index.mjs'], {
+    cwd: BUNKER_DIR,
+    env: { ...process.env, HEARTWOOD_DATA_DIR: dataDir, HEARTWOOD_AUTHORIZED_KEYS: clientPk },
+  })
+  const logs = []
+  child.stdout.on('data', (d) => logs.push(`[sidecar] ${d}`.trimEnd()))
+  child.stderr.on('data', (d) => logs.push(`[sidecar:err] ${d}`.trimEnd()))
+
+  try {
+    // Wait for the sidecar to mint URIs and subscribe for the master identity.
+    const urisPath = join(dataDir, 'bunker-uris.json')
+    for (let i = 0; i < 100 && !existsSync(urisPath); i++) await sleep(100)
+    if (!existsSync(urisPath)) throw new Error('sidecar never wrote bunker-uris.json')
+    const manifest = JSON.parse(readFileSync(urisPath, 'utf-8'))
+    const masterPk = manifest.find((m) => m.label === 'master')?.pubkey
+    for (let i = 0; i < 100 && !relay.subscribedPubkeys.has(masterPk); i++) await sleep(100)
+
+    console.log(`\nManifest has ${manifest.length} identities: ${manifest.map((m) => m.label).join(', ')}`)
+    check(manifest.length === 3, 'manifest lists master + 2 personas')
+    for (const p of personas) {
+      const entry = manifest.find((m) => m.label === p.name)
+      check(entry?.pubkey === p.pubkey, `persona "${p.name}" pubkey matches independent derivation`)
+      check(entry?.uri.startsWith(`bunker://${p.pubkey}?`), `persona "${p.name}" URI is addressed to its own pubkey`)
+    }
+
+    const seen = []
+    for (const entry of manifest) {
+      const { pubkey: signerPk, relay: relayUrl } = parseBunkerUri(entry.uri)
+      const ack = await nip46Call(relayUrl, signerPk, clientSk, 'connect', [signerPk])
+      check(ack === 'ack', `[${entry.label}] connect → ack`)
+
+      const pk = await nip46Call(relayUrl, signerPk, clientSk, 'get_public_key', [])
+      check(pk === entry.pubkey, `[${entry.label}] get_public_key returns the addressed identity`)
+
+      const tmpl = JSON.stringify({ kind: 1, created_at: nowSec(), tags: [], content: `hi from ${entry.label}` })
+      const signed = JSON.parse(await nip46Call(relayUrl, signerPk, clientSk, 'sign_event', [tmpl]))
+      check(signed.pubkey === entry.pubkey, `[${entry.label}] sign_event signs AS the addressed identity`)
+      check(verifyEvent(signed) === true, `[${entry.label}] signed event has a valid signature`)
+      seen.push(signed.pubkey)
+    }
+    check(new Set(seen).size === 3, 'all three identities signed with distinct keys')
+
+    // A request addressed to an unknown pubkey must be ignored (no response).
+    const stranger = getPublicKey(generateSecretKey())
+    let strayResolved = false
+    await nip46Call(relay.url, stranger, clientSk, 'get_public_key', [], 2500)
+      .then(() => (strayResolved = true))
+      .catch(() => {})
+    check(!strayResolved, 'request to an unknown identity is ignored (times out, no signer)')
+  } catch (e) {
+    failures++
+    console.log(`\n✘ harness error: ${e.message}`)
+    console.log(logs.join('\n'))
+  } finally {
+    child.kill('SIGKILL')
+    relay.wss.close()
+    rmSync(dataDir, { recursive: true, force: true })
+  }
+
+  console.log(`\n${failures === 0 ? '✔ ALL PASSED' : `✘ ${failures} FAILED`}`)
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main()

--- a/bunker/test/setup-personas.mjs
+++ b/bunker/test/setup-personas.mjs
@@ -1,0 +1,50 @@
+/**
+ * Dev helper: prepare a throwaway data dir with N personas + a connect-slot
+ * secret (for auto-approval), and print one bunker URI per persona for manual
+ * client testing (Coracle, noStrudel, ...). Pair with:
+ *
+ *   SERVE_DIR=/tmp/hw node test/setup-personas.mjs        # prepare + print URIs
+ *   HEARTWOOD_DATA_DIR=/tmp/hw node index.mjs             # run the bunker
+ *
+ * Env: SERVE_DIR (required), RELAYS (comma-sep, default public), PERSONAS.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { generateSecretKey } from 'nostr-tools/pure'
+import { bytesToHex } from 'nostr-tools/utils'
+import { fromMnemonic } from 'nsec-tree/mnemonic'
+import { derivePersona } from 'nsec-tree/persona'
+
+const dir = process.env.SERVE_DIR
+if (!dir) {
+  console.error('SERVE_DIR is required')
+  process.exit(1)
+}
+const relays = (process.env.RELAYS || 'wss://relay.nsec.app,wss://relay.damus.io,wss://nos.lol').split(',')
+const names = (process.env.PERSONAS || 'work,fun').split(',')
+
+let mnemonic
+try {
+  const { generateMnemonic } = await import('@scure/bip39')
+  const { wordlist } = await import('@scure/bip39/wordlists/english')
+  mnemonic = generateMnemonic(wordlist, 128)
+} catch {
+  mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+}
+
+const treeRoot = fromMnemonic(mnemonic)
+const personas = names.map((name) => {
+  const d = derivePersona(treeRoot, name.trim(), 0)
+  return { name: name.trim(), pubkey: bytesToHex(d.identity.publicKey), purpose: d.identity.purpose, index: d.index }
+})
+const secret = bytesToHex(generateSecretKey())
+
+mkdirSync(dir, { recursive: true })
+writeFileSync(`${dir}/master.payload`, `tree-mnemonic::${mnemonic}`)
+writeFileSync(`${dir}/config.json`, JSON.stringify({ relays }))
+writeFileSync(`${dir}/personas.json`, JSON.stringify(personas))
+writeFileSync(`${dir}/slots.json`, JSON.stringify({ [secret]: { label: 'manual-test' } }))
+
+const relayParams = relays.map((r) => `relay=${encodeURIComponent(r)}`).join('&')
+const lines = personas.map((p) => `${p.name}: bunker://${p.pubkey}?${relayParams}&secret=${secret}`)
+writeFileSync(`${dir}/uris.txt`, lines.join('\n') + '\n')
+console.log(lines.join('\n'))

--- a/crates/heartwood-device/src/web.rs
+++ b/crates/heartwood-device/src/web.rs
@@ -1227,6 +1227,73 @@ async fn api_bunker(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     }
 }
 
+/// `GET /api/identities` — list the per-identity bunker URIs the sidecar minted.
+///
+/// The bunker sidecar writes `bunker-uris.json` (`[{label, pubkey, npub, uri}]`,
+/// master + every derived persona). Each identity is its own NIP-46 connection,
+/// so a client can add several as separate accounts and switch between them
+/// without signing out. Returns an empty list if the file is missing (e.g. the
+/// bunker is not running, or an older sidecar that predates the manifest).
+async fn api_identities(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let identities = std::fs::read_to_string(state.data_file("bunker-uris.json"))
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .unwrap_or_else(|| json!([]));
+    axum::Json(json!({ "identities": identities }))
+}
+
+/// Look up an identity's bunker URI from the sidecar's `bunker-uris.json`.
+fn identity_uri(state: &AppState, pubkey: &str) -> Option<String> {
+    let manifest: Vec<serde_json::Value> =
+        std::fs::read_to_string(state.data_file("bunker-uris.json"))
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+    manifest.iter().find_map(|m| {
+        if m.get("pubkey").and_then(|v| v.as_str()) == Some(pubkey) {
+            m.get("uri").and_then(|v| v.as_str()).map(str::to_string)
+        } else {
+            None
+        }
+    })
+}
+
+#[derive(Deserialize)]
+struct IdentityQrQuery {
+    pubkey: String,
+}
+
+/// `GET /api/identities/qr?pubkey=<hex>` — an SVG QR code of that identity's
+/// bunker URI, for scanning into a mobile NIP-46 client.
+async fn api_identity_qr(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Query(q): axum::extract::Query<IdentityQrQuery>,
+) -> impl IntoResponse {
+    let Some(uri) = identity_uri(&state, &q.pubkey) else {
+        return (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/plain")],
+            "unknown identity".to_string(),
+        );
+    };
+    match qrcode::QrCode::new(uri.as_bytes()) {
+        Ok(code) => {
+            let svg = code
+                .render::<qrcode::render::svg::Color>()
+                .min_dimensions(220, 220)
+                .dark_color(qrcode::render::svg::Color("#000000"))
+                .light_color(qrcode::render::svg::Color("#ffffff"))
+                .build();
+            (StatusCode::OK, [(header::CONTENT_TYPE, "image/svg+xml")], svg)
+        }
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain")],
+            "qr generation failed".to_string(),
+        ),
+    }
+}
+
 /// `GET /api/bunker/status` — return relay connection status from the bunker sidecar.
 ///
 /// The bunker sidecar writes `bunker-status.json` every 15 seconds with per-relay
@@ -1675,6 +1742,10 @@ async fn api_pair(
 #[derive(Deserialize)]
 struct CreateSlotRequest {
     label: String,
+    /// Identity pubkey (hex) to attach the auto-approve secret to. Defaults to
+    /// the master bunker URI when absent.
+    #[serde(default)]
+    identity: Option<String>,
 }
 
 /// `POST /api/slots/create` — create a pre-authorised connect slot.
@@ -1700,13 +1771,19 @@ async fn api_create_slot(
     rand_core::OsRng.fill_bytes(&mut secret_bytes);
     let secret: String = secret_bytes.iter().map(|b| format!("{b:02x}")).collect();
 
-    // Read bunker URI
-    let bunker_uri = match std::fs::read_to_string(state.data_file("bunker-uri.txt")) {
-        Ok(uri) => uri.trim().to_string(),
-        Err(_) => {
+    // Base URI: the chosen identity's URI, or the master URI by default.
+    let base_uri = match &req.identity {
+        Some(pubkey) => identity_uri(&state, pubkey),
+        None => std::fs::read_to_string(state.data_file("bunker-uri.txt"))
+            .ok()
+            .map(|s| s.trim().to_string()),
+    };
+    let bunker_uri = match base_uri {
+        Some(uri) => uri,
+        None => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                axum::Json(json!({"error": "bunker not running"})),
+                axum::Json(json!({"error": "bunker not running or unknown identity"})),
             );
         }
     };
@@ -1955,6 +2032,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/relays", get(api_get_relays).post(api_set_relays))
         .route("/api/bunker", get(api_bunker))
         .route("/api/bunker/status", get(api_bunker_status))
+        .route("/api/identities", get(api_identities))
+        .route("/api/identities/qr", get(api_identity_qr))
         .route("/api/password", post(api_set_password))
         .route("/api/tor", get(api_get_tor).post(api_set_tor))
         .route("/api/restart", post(api_restart))

--- a/web/index.html
+++ b/web/index.html
@@ -296,6 +296,12 @@
                 <p class="warn">Paste this into NostrHub, Amethyst, or any NIP-46 client to connect.</p>
             </div>
 
+            <div id="identities-section" class="hidden" style="margin-top:1.5rem;">
+                <p class="label">Identities</p>
+                <p class="warn" style="margin-top:0;">Each identity has its own connection string. Paste one into a NIP-46 client (Coracle, noStrudel, Amethyst…); add several as separate accounts and switch between them without signing out.</p>
+                <div id="identities-list"></div>
+            </div>
+
             <div id="onion-section" class="hidden" style="margin-top:1.5rem;">
                 <p class="label">Tor address</p>
                 <div style="position:relative;">
@@ -910,6 +916,118 @@
                     document.getElementById('bunker-uri-section').classList.remove('hidden');
                 }
             } catch { /* ignore — URI will refresh on next full page load */ }
+            loadIdentities();
+        }
+
+        /** Fetch the per-identity bunker URIs and render them as a list. Falls
+         *  back to the single master-URI section when the sidecar hasn't written
+         *  the manifest (older sidecar or bunker not running). */
+        async function loadIdentities() {
+            try {
+                const res = await fetch('/api/identities');
+                const data = await res.json();
+                const list = Array.isArray(data.identities) ? data.identities : [];
+                if (list.length === 0) return;
+                const container = document.getElementById('identities-list');
+                container.innerHTML = '';
+                list.forEach((id) => {
+                    const row = document.createElement('div');
+                    row.style.marginBottom = '1rem';
+
+                    const label = document.createElement('p');
+                    label.className = 'label';
+                    label.style.margin = '0 0 0.2rem';
+                    label.textContent = id.label;
+
+                    const npub = document.createElement('div');
+                    npub.style.cssText = 'font-size:0.7rem; opacity:0.6; word-break:break-all; margin-bottom:0.25rem;';
+                    npub.textContent = id.npub || '';
+
+                    const wrap = document.createElement('div');
+                    wrap.style.position = 'relative';
+                    const uri = document.createElement('div');
+                    uri.className = 'npub';
+                    uri.style.paddingRight = '3rem';
+                    uri.textContent = id.uri;
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Copy';
+                    btn.style.cssText = 'position:absolute; right:0.4rem; top:50%; transform:translateY(-50%); background:#2a2a2a; border:1px solid #444; border-radius:4px; color:#ccc; padding:0.3rem 0.5rem; cursor:pointer; font-size:0.75rem;';
+                    btn.addEventListener('click', () => copyToClipboard(uri.textContent, btn));
+                    wrap.appendChild(uri);
+                    wrap.appendChild(btn);
+
+                    // Per-identity actions: show a QR code, or swap in an auto-approve link.
+                    const actions = document.createElement('div');
+                    actions.style.cssText = 'margin-top:0.4rem; display:flex; gap:1.25rem;';
+                    const linkStyle = 'background:none; border:none; color:#6ea8fe; padding:0; cursor:pointer; font-size:0.75rem;';
+
+                    const qrBtn = document.createElement('button');
+                    qrBtn.textContent = 'Show QR';
+                    qrBtn.style.cssText = linkStyle;
+                    const qrBox = document.createElement('div');
+                    qrBox.className = 'hidden';
+                    qrBox.style.cssText = 'margin-top:0.5rem; width:200px;';
+                    qrBtn.addEventListener('click', () => {
+                        if (qrBox.classList.contains('hidden')) {
+                            if (!qrBox.dataset.loaded) {
+                                const img = document.createElement('img');
+                                img.src = '/api/identities/qr?pubkey=' + encodeURIComponent(id.pubkey);
+                                img.alt = 'QR code for ' + id.label;
+                                img.style.cssText = 'width:100%; display:block; background:#fff; border-radius:6px; padding:8px; box-sizing:border-box;';
+                                qrBox.appendChild(img);
+                                qrBox.dataset.loaded = '1';
+                            }
+                            qrBox.classList.remove('hidden');
+                            qrBtn.textContent = 'Hide QR';
+                        } else {
+                            qrBox.classList.add('hidden');
+                            qrBtn.textContent = 'Show QR';
+                        }
+                    });
+
+                    const slotBtn = document.createElement('button');
+                    slotBtn.textContent = 'Auto-approve link';
+                    slotBtn.title = 'Swap in a connection link that auto-approves the client — no separate approval step.';
+                    slotBtn.style.cssText = linkStyle;
+                    slotBtn.addEventListener('click', async () => {
+                        slotBtn.textContent = 'Creating…';
+                        slotBtn.disabled = true;
+                        try {
+                            const r = await fetch('/api/slots/create', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ label: id.label, identity: id.pubkey }),
+                            });
+                            const d = await r.json();
+                            if (d.bunker_uri) {
+                                uri.textContent = d.bunker_uri;   // Copy now yields the auto-approve URI
+                                qrBtn.style.display = 'none';      // server QR can't carry the secret
+                                qrBox.classList.add('hidden');
+                                slotBtn.textContent = 'Auto-approve on ✓';
+                                slotBtn.style.color = '#3fb950';
+                            } else {
+                                slotBtn.textContent = d.error ? ('Error: ' + d.error) : 'Failed';
+                                slotBtn.disabled = false;
+                            }
+                        } catch {
+                            slotBtn.textContent = 'Failed';
+                            slotBtn.disabled = false;
+                        }
+                    });
+
+                    actions.appendChild(qrBtn);
+                    actions.appendChild(slotBtn);
+
+                    row.appendChild(label);
+                    row.appendChild(npub);
+                    row.appendChild(wrap);
+                    row.appendChild(actions);
+                    row.appendChild(qrBox);
+                    container.appendChild(row);
+                });
+                document.getElementById('identities-section').classList.remove('hidden');
+                document.getElementById('bunker-uri-section').classList.add('hidden');
+            } catch { /* ignore — keep the single bunker URI fallback */ }
         }
 
         // --- Bunker URI ---
@@ -1317,6 +1435,7 @@
                         document.getElementById('bunker-uri').textContent = d.bunker_uri;
                         document.getElementById('bunker-uri-section').classList.remove('hidden');
                     }
+                    loadIdentities();
                     if (d.onion_address) {
                         document.getElementById('onion-address').textContent = d.onion_address;
                         document.getElementById('onion-section').classList.remove('hidden');


### PR DESCRIPTION
Lets one Heartwood serve several identities (master + derived personas), each as its own `bunker://<npub>` URI, so a stock client like Coracle/noStrudel holds them as separate accounts and switches between them **without signing out**.

## What
- **Sidecar** (`bunker/index.mjs`): route each NIP-46 request by its `#p` target; each identity's own key does both NIP-44 transport and signing; drop the global active-identity pointer. Handle `switch_relays` (Coracle/welshman call it right after `connect` and stall until it succeeds — without this, login never completes).
- **Device** (`web.rs`, `index.html`): `GET /api/identities` + `/api/identities/qr`; an Identities list with copy, QR, and per-identity auto-approve links; slot creation can attach the connect secret to a chosen identity.

## Verified
- `bunker/test/personas-integration.mjs` — 19/19 (per-`#p` routing returns/sign as the addressed identity, all distinct, unknown targets ignored).
- Live **Coracle**: two personas added as two accounts (`sessions` Record holds both), switched via "Switch Account" with **no re-login**, correct author per account.
- Device endpoints curl-tested on the real binary (`/api/identities`, QR → valid SVG, per-identity slot URIs); web-UI render verified.

## Notes
- Breaking: the software master URI is now `bunker://<master npub>` (was the separate bunker-key pubkey) — existing clients re-add once.
- Companion firmware change (HSM mode) is in heartwood-esp32 `feat/per-identity-hsm-signing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
