### PR TITLE
feat: allow the Sapwood dev origin in debug builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "serialport",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "zeroize",
@@ -1594,6 +1595,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/crates/heartwood-device/Cargo.toml
+++ b/crates/heartwood-device/Cargo.toml
@@ -27,6 +27,8 @@ zeroize = "1"
 bip39 = "2"
 serialport = { version = "4", default-features = false } # no libudev: sysfs enumeration suffices and cross-builds stay linkable
 heartwood-frame = { path = "../heartwood-frame" }
+# Debug-build-only CORS for the Sapwood dev server (see web.rs create_router).
+tower-http = { version = "0.6", features = ["cors"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util", "macros"] }

--- a/crates/heartwood-device/src/web.rs
+++ b/crates/heartwood-device/src/web.rs
@@ -2018,10 +2018,14 @@ async fn api_hsm_detect() -> impl IntoResponse {
 
 /// Build and return the application router.
 ///
-/// No CORS layer is applied — the web UI uses same-origin requests.
-/// Cross-origin access is denied by default for security.
+/// Release builds apply no CORS layer — the web UI uses same-origin requests
+/// and cross-origin access is denied by default for security. Debug builds
+/// additionally allow exactly the Sapwood dev server's origin
+/// (`http://localhost:5173`), so `npm run dev` in sapwood can talk to a local
+/// device without a rebuild. Never permissive: the allowance is one pinned
+/// localhost origin, and it is compiled out of release binaries entirely.
 pub fn create_router(state: Arc<AppState>) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/", get(serve_index))
         .route("/api/status", get(api_status))
         .route("/api/setup", post(api_setup))
@@ -2054,7 +2058,24 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .layer(middleware::from_fn_with_state(state.clone(), lock_middleware))
         .layer(middleware::from_fn_with_state(state.clone(), auth_middleware))
         .layer(DefaultBodyLimit::max(65536))
-        .with_state(state)
+        .with_state(state);
+
+    #[cfg(debug_assertions)]
+    let router = {
+        use tower_http::cors::{AllowHeaders, AllowMethods, CorsLayer};
+        router.layer(
+            CorsLayer::new()
+                .allow_origin(
+                    "http://localhost:5173"
+                        .parse::<axum::http::HeaderValue>()
+                        .expect("static origin parses"),
+                )
+                .allow_methods(AllowMethods::mirror_request())
+                .allow_headers(AllowHeaders::mirror_request()),
+        )
+    };
+
+    router
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves the parked dev-CORS stash from refactor/boards-pi-rename,
whose comment promised localhost:5173 while the code granted
CorsLayer::permissive(). The reconciled version allows exactly the
Sapwood dev server's origin (http://localhost:5173) with mirrored
methods/headers, and only under cfg(debug_assertions) — release
binaries compile the layer out entirely and stay same-origin-only.
